### PR TITLE
Bogo Sort in Haskell

### DIFF
--- a/chapters/sorting_searching/bogo/bogo_sort.md
+++ b/chapters/sorting_searching/bogo/bogo_sort.md
@@ -1,7 +1,7 @@
 <script>
 MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
 </script>
-$$ 
+$$
 \newcommand{\d}{\mathrm{d}}
 \newcommand{\bff}{\boldsymbol{f}}
 \newcommand{\bfg}{\boldsymbol{g}}
@@ -22,7 +22,7 @@ $$
 $$
 
 # Bogo Sort
-Look, Bogo Sort doesn't really sort anything out. 
+Look, Bogo Sort doesn't really sort anything out.
 In fact, it should never be used in practice for any reason I can think of and really only serves as a joke in the programming community.
 As far as jokes go, though, this one's pretty good.
 
@@ -46,6 +46,8 @@ In code, it looks something like this:
 [import:4-27, lang:"c_cpp"](code/c/bogo_sort.c)
 {% sample lang="js" %}
 [import:1-16, lang:"javascript"](code/js/bogo.js)
+{% sample lang="hs" %}
+[import, lang:"haskell"](code/haskell/bogoSort.hs)
 {% endmethod %}
 
 That's it.

--- a/chapters/sorting_searching/bogo/code/haskell/bogoSort.hs
+++ b/chapters/sorting_searching/bogo/code/haskell/bogoSort.hs
@@ -1,0 +1,24 @@
+import           System.Random
+import qualified Data.Map as M
+import           Data.Map ((!))
+
+fisherYates :: RandomGen g => [a] -> g -> ([a], g)
+fisherYates a gen = shuffle 1 gen m
+  where m = M.fromList $ zip [1..] a
+        shuffle i g k
+          | i == M.size m = (M.elems k, g)
+          | otherwise     = let (j, g') = randomR (i, M.size m) g
+                                k' = M.insert i (k!j) $ M.insert j (k!i) k
+                            in shuffle (i+1) g' k'
+
+isSorted :: Ord a => [a] -> Bool
+isSorted = all (uncurry (<=)) . (zip <*> tail)
+
+bogoSort :: (Ord a, RandomGen g) => g -> [a] -> [a]
+bogoSort g a = fst $ head $
+               filter (isSorted . fst) $
+               iterate (uncurry fisherYates) (a, g)
+
+main = do
+  g <- newStdGen
+  print $ bogoSort g [9, 4, 3, 2, 5, 8, 6, 1, 7]


### PR DESCRIPTION
Added bogo sort, cleaned out trailing spaces too.
I left the implementation for shuffling because it's not part of core libraries in Haskell.