### PR TITLE
Add a margin at the bottom of every page

### DIFF
--- a/styles/website.css
+++ b/styles/website.css
@@ -7,5 +7,5 @@
 }
 
 .book .book-body .page-wrapper {
-  margin-bottom: 15em;
+  margin-bottom: 12em;
 }

--- a/styles/website.css
+++ b/styles/website.css
@@ -3,5 +3,9 @@
 }
 
 .book .book-body .page-wrapper .page-inner section.normal .hljs-meta-string {
-  color: #718c00; 
+  color: #718c00;
+}
+
+.book .book-body .page-wrapper {
+  margin-bottom: 15em;
 }


### PR DESCRIPTION
When I brought up the AAA a few days ago, a friend of mine brought up that he doesn't like how the chapter text ends at the very bottom of the page. [The Introduction chapter is a good example](https://algorithm-archivists.github.io/chapters/introduction.html) - the last line of text is at the very bottom of the monitor when viewing the page in fullscreen. I see where he's coming from, so I tried adding a margin at the bottom and I think it's nicer this way. What do you all think?