### PR TITLE
Add import for the Python Huffman implementation to the chapter

### DIFF
--- a/chapters/data_compression/huffman/huffman.md
+++ b/chapters/data_compression/huffman/huffman.md
@@ -72,6 +72,9 @@ Whether you use a stack or straight-up recursion also depends on the language, b
 {% sample lang="clj" %}
 ### Clojure
 [import 2-117, lang:"clojure"](code/clojure/huffman.clj)
+{% sample lang="py" %}
+### Python
+[import, lang:"python"](code/python/huffman.py)
 {% endmethod %}
 
 


### PR DESCRIPTION
This PR adds an import statement for the code submitted in #98 to the corresponding markdown file.