### PR TITLE
 Adding missing examples for Tree Traversal and FFT in C++.

### DIFF
--- a/chapters/FFT/code/c++/fft.cpp
+++ b/chapters/FFT/code/c++/fft.cpp
@@ -75,6 +75,7 @@ void sort_by_bit_reverse(Iter first, Iter last) {
     auto a = i;
     auto current_count = count;
 
+    // this left shifts i and right shifts the shifted bit to n by bitwise or
     n >>= 1;
     while (n > 0) {
       a = (a << 1) | (n & 1);

--- a/chapters/FFT/code/c++/fft.cpp
+++ b/chapters/FFT/code/c++/fft.cpp
@@ -111,26 +111,37 @@ void iterative(Iter first, Iter last) {
   }
 }
 
-template <typename Iter>
-void discrete(Iter first, Iter last) {
-  auto size = last - first;
-  auto temp = std::vector<c64>(size);
+template <typename It, typename F>
+auto sum(It const first, It const last, F f) {
+  using return_type = decltype(f(0, *first));
+  auto ret = return_type(0);
 
   std::size_t i = 0;
-  std::generate(begin(temp), end(temp), [&i, size, first, last] {
-    std::size_t j = 0;
+  for (auto it = first; it < last; ++it, ++i) {
+    ret += f(i, *it);
+  }
 
-    auto ret = std::accumulate(
-        first, last, c64(0), [i, &j, size](auto& acc, auto& it) {
-          auto res = it * std::exp(c64(0, -2.0 * pi<double>() * j * i / size));
-          ++j;
-          return acc + res;
+  return ret;
+}
+
+template <typename Iter>
+void discrete(Iter const first, Iter const last) {
+  using namespace std::literals;
+
+  auto const original = std::vector<c64>(first, last);
+  auto const size = original.size();
+
+  auto const i2pi = -2.0i * pi<double>();
+
+  for (std::size_t i = 0; i < size; ++i) {
+  for (std::size_t i = 0; i < size; ++i) {
+    first[i] =
+        sum(begin(original), end(original), [&](auto const k, auto const el) {
+          return el * std::exp(i2pi * double(i * k) / double(size));
         });
-    ++i;
-    return ret;
-  });
+  }
 
-  std::copy(begin(temp), end(temp), first);
+  }
 }
 
 } // namespace ct

--- a/chapters/tree_traversal/code/c++/tree_example.cpp
+++ b/chapters/tree_traversal/code/c++/tree_example.cpp
@@ -26,6 +26,33 @@ void dfs_recursive(node const& n) {
   }
 }
 
+void dfs_recursive_postorder(node const& n) {
+  for (auto const& child : n.children) {
+    dfs_recursive_postorder(child);
+  }
+  std::cout << n.value << '\n';
+}
+
+void dfs_recursive_inorder_btree(node const& n) {
+  switch (n.children.size()) {
+  case 2:
+    dfs_recursive_inorder_btree(n.children[0]);
+    std::cout << n.value << '\n';
+    dfs_recursive_inorder_btree(n.children[1]);
+    break;
+  case 1:
+    dfs_recursive_inorder_btree(n.children[0]);
+    std::cout << n.value << '\n';
+    break;
+  case 0:
+    std::cout << n.value << '\n';
+    break;
+  default:
+    std::cout << "This is not a binary tree.\n";
+    break;
+  }
+}
+
 // Simple non-recursive scheme for DFS
 void dfs_stack(node const& n) {
   // this stack holds pointers into n's `children` vector,
@@ -67,7 +94,7 @@ node create_tree(size_t num_row, size_t num_child) {
 
   std::vector<node> vec;
   std::generate_n(std::back_inserter(vec), num_child, [&] {
-    return create_node(num_row - 1, num_child);
+    return create_tree(num_row - 1, num_child);
   });
 
   return node{std::move(vec), num_row};
@@ -75,8 +102,8 @@ node create_tree(size_t num_row, size_t num_child) {
 
 int main() {
   // Creating Tree in main
-  auto root = create_node(3, 3);
+  auto root = create_tree(3, 2);
   dfs_recursive(root);
-  dfs_stack(root);
-  bfs_queue(root);
+  //dfs_stack(root);
+  //bfs_queue(root);
 }


### PR DESCRIPTION
I added `DFT` to FFT, `DFS_recursive_postorder` and `DFS_recursive_inorder_btree` to tree traversal all in C++.