### PR TITLE
Fix example to use 1-based indexing in Julia example

### DIFF
--- a/chapters/principles_of_code/notation/notation.md
+++ b/chapters/principles_of_code/notation/notation.md
@@ -73,7 +73,7 @@ Let's consider the following function:
 
 ```julia
 function linear(a::Array{Float64})
-    for i = 0:length(a)
+    for i = 1:length(a)
         println(a[i])
     end
 end


### PR DESCRIPTION
Fixes #123 according to description/instructions given in the issue.