### PR TITLE
Removed unwanted end-of-line conversions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Force all text files to have LF line endings
 * text=auto eol=lf
+*.png -text
+*.jpg -text
+*.gif -text


### PR DESCRIPTION
Removes every EOL conversion for every PNG, JPG and GIF files that Git may attempt (note: there is currently 26 PNG, 8 JPG and one GIF that Git warns about).