### PR TITLE
Add Python3 code to Verlet

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ Gathros
 Jeremie Gillet (- Jie -)
 Salim Khatib
 Hitesh C
+Hugo Granström

--- a/chapters/physics_solvers/verlet/code/python3/verlet.py
+++ b/chapters/physics_solvers/verlet/code/python3/verlet.py
@@ -1,0 +1,67 @@
+# submitted by HugoGranstrom
+
+def verlet_step(pos_prev, pos, acc, dt):
+    pos_next = 2 * pos - pos_prev + acc * dt * dt
+    return pos_next
+
+# calculate velocity at the current timestep
+def stormer_verlet_current(pos_prev, pos_next, dt):
+    vel_current = (pos_next - pos_prev) / (2 * dt)
+    return vel_current
+
+#calculate velocity at the next timestep
+def stormer_verlet_next(pos_next, pos, dt):
+    vel_next = (pos_next - pos) / (dt)
+    return vel_next
+
+def acc_func(pos):
+    # write the function for acceleration here, for example acc = F/m 
+    # now acc is constant and independent of pos, thus pos is not used
+    # for other implentations it can be used though
+    return -10
+
+def velocity_verlet_step(pos, vel, acc, dt):
+    pos_next = pos + vel * dt + 0.5 * acc * dt * dt
+    acc_next = acc_func(pos_next)
+    vel_next = vel + 0.5 * (acc + acc_next) * dt
+    return pos_next, vel_next, acc_next
+
+# HugoGranstrom
+# example calculating time it takes for an object to fall 5 m with acc = -10
+# because acc is constant, all 0.5 * (acc + acc_next) * dt becomes just acc * dt
+
+def run_verlet(pos_start, acc, dt):
+    time = 0
+    pos = pos_start
+    pos_prev = pos_start
+
+    while pos > 0:
+        # calculate next timestep
+        pos_next = 2 * pos - pos_prev + acc * dt * dt
+
+        # prepare for next timestep
+        pos_prev = pos
+        pos = pos_next
+        time += dt
+    
+    print(f"Classic Verlet took {time} seconds")
+
+def run_velocity_verlet(pos_start, vel_start, acc, dt):
+    time = 0
+    pos = pos_start
+    vel = vel_start
+
+    while pos > 0:
+        # calculate next timestep
+        pos_next = pos + vel * dt + 0.5 * acc * dt * dt
+        vel_next = vel + acc * dt
+
+        # prepare for next timestep
+        pos = pos_next
+        vel = vel_next
+        time += dt
+    
+    print(f"Velocity Verlet took {time} seconds")
+
+run_verlet(5, -10, 0.01)
+run_velocity_verlet(5, 0, -10, 0.01)

--- a/chapters/physics_solvers/verlet/verlet.md
+++ b/chapters/physics_solvers/verlet/verlet.md
@@ -40,7 +40,7 @@ Here is what it looks like in code:
 [import:2-18, lang:"java"](code/java/verlet.java)
 {% sample lang="py2" %}
 [import:28-33, lang:"python"](code/python2/verlet.py)
-{% sample lang="py3" %}
+{% sample lang="py" %}
 [import:3-5, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in haskell, so here's Julia code:
@@ -88,7 +88,7 @@ Here's what it looks like in code:
 [import:21-40, lang:"java"](code/java/verlet.java)
 {% sample lang="py2" %}
 [import:35-42, lang:"python"](code/python2/verlet.py)
-{% sample lang="py3" %}
+{% sample lang="py" %}
 [import:7-15, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in scratch, so here's Julia code:
@@ -147,7 +147,7 @@ Here is the velocity Verlet method in code:
 [import:43-57, lang:"java"](code/java/verlet.java)
 {% sample lang="py2" %}
 [import:44-48, lang:"python"](code/python2/verlet.py)
-{% sample lang="py3" %}
+{% sample lang="py" %}
 [import:17-27, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in haskell, so here's Julia code:
@@ -190,8 +190,8 @@ Both of these methods work simply by iterating timestep-by-timestep and can be w
 {% sample lang="py2" %}
 ### Python
 [import, lang:"python"](code/python2/verlet.py)
-{% sample lang="py3" %}
-### Python 3
+{% sample lang="py" %}
+### Python
 [import:29-67, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 ### Haskell

--- a/chapters/physics_solvers/verlet/verlet.md
+++ b/chapters/physics_solvers/verlet/verlet.md
@@ -40,6 +40,8 @@ Here is what it looks like in code:
 [import:2-18, lang:"java"](code/java/verlet.java)
 {% sample lang="py2" %}
 [import:28-33, lang:"python"](code/python2/verlet.py)
+{% sample lang="py3" %}
+[import:3-5, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in haskell, so here's Julia code:
 [import:1-13, lang:"julia"](code/julia/verlet.jl)
@@ -86,6 +88,8 @@ Here's what it looks like in code:
 [import:21-40, lang:"java"](code/java/verlet.java)
 {% sample lang="py2" %}
 [import:35-42, lang:"python"](code/python2/verlet.py)
+{% sample lang="py3" %}
+[import:7-15, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in scratch, so here's Julia code:
 [import:15-31, lang:"julia"](code/julia/verlet.jl)
@@ -143,6 +147,8 @@ Here is the velocity Verlet method in code:
 [import:43-57, lang:"java"](code/java/verlet.java)
 {% sample lang="py2" %}
 [import:44-48, lang:"python"](code/python2/verlet.py)
+{% sample lang="py3" %}
+[import:17-27, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in haskell, so here's Julia code:
 [import:33-45, lang:"julia"](code/julia/verlet.jl)
@@ -184,6 +190,9 @@ Both of these methods work simply by iterating timestep-by-timestep and can be w
 {% sample lang="py2" %}
 ### Python
 [import, lang:"python"](code/python2/verlet.py)
+{% sample lang="py3" %}
+### Python 3
+[import:29-67, lang="python"](code/python3/verlet.py)
 {% sample lang="hs" %}
 ### Haskell
 [import, lang:"haskell"](code/haskell/verlet.hs)


### PR DESCRIPTION
There was already Python2 code included in the article but as newcomers to Python should learn Python3 it makes sense to also add Python3 code. Hope my code makes sense. 
In the last example I left Stormer-Verlet out because it is just Classical Verlet but you calculate the velocity but you don't use it in this example with the falling ball.  