### PR TITLE
Correct bogosort's best case runtime

### DIFF
--- a/chapters/sorting_searching/bogo/bogo_sort.md
+++ b/chapters/sorting_searching/bogo/bogo_sort.md
@@ -8,7 +8,7 @@ imagine you have an array of $$n$$ elements that you want sorted.
 One way to do it is to shuffle the array at random and hope that all the elements will be magically in order after shuffling.
 If they are not in order, just shuffle everything again.
 And then again. And again.
-In the best case, this algorithm runs with a complexity of $$\Omega(1)$$, and in the worst, $$\mathcal{O}(\infty)$$.
+In the best case, this algorithm runs with a complexity of $$\Omega(n)$$, and in the worst, $$\mathcal{O}(\infty)$$.
 
 In code, it looks something like this:
 


### PR DESCRIPTION
Bogosort's best case runtime is not constant, because even if the array
is already sorted, it still has to perform Θ(n) operations to verify
that each of the n elements are in order.