### PR TITLE
Update Tree Traversal C#.

### DIFF
--- a/chapters/tree_traversal/code/cs/Program.cs
+++ b/chapters/tree_traversal/code/cs/Program.cs
@@ -17,6 +17,7 @@ namespace TreeTraversal
             tree.BFSQueue();
             Console.WriteLine("DFSRecursivePostorder");
             tree.DFSRecursivePostorder();
+
             // Uncommenting the following 2 lines will result in an exception thrown because at least one Node of the Tree has more than 2 children and therefor a DFSRecursiveInorderBinary doesn't work.
             // Console.WriteLine("DFSRecursiveInorder (fail)");
             // tree.DFSRecursiveInorderBinary();

--- a/chapters/tree_traversal/code/cs/Tree.cs
+++ b/chapters/tree_traversal/code/cs/Tree.cs
@@ -6,110 +6,107 @@ namespace TreeTraversal
 {
     public class Tree
     {
-        private class Node
-        {
-            public List<Node> Children { get; set; } = new List<Node>();
-            public int Id { get; set; }
-
-            public Node(int id) => this.Id = id;
-        }
-
-        private Node root;
+        public int Id { get; private set; }
+        private List<Tree> _children = new List<Tree>();
 
         public Tree(int depthCount, int childrenCount)
         {
-            root = new Node(1);
-            CreateAllChildren(root, depthCount, childrenCount);
+            this.Id = 1;
+
+            if (!(depthCount <= 1))
+            {
+                for (int i = 0; i < childrenCount; i++)
+                    this._children.Add(new Tree(this.Id * 10 + i + 1, depthCount - 1, childrenCount));
+            }
+        }
+
+        private Tree(int id, int depthCount, int childrenCount)
+        {
+            this.Id = id;
+
+            if (!(depthCount <= 1))
+            {
+                for (int i = 0; i < childrenCount; i++)
+                    this._children.Add(new Tree(this.Id * 10 + i + 1, depthCount - 1, childrenCount));
+            }
         }
 
         public void DFSRecursive()
         {
-            DFSRecursive(root);
+            DFSRecursive(this);
 
-            void DFSRecursive(Node node)
+            void DFSRecursive(Tree tree)
             {
-                Console.WriteLine(node.Id);
+                Console.WriteLine(tree.Id);
 
-                foreach (var c in node.Children)
+                foreach (var c in tree._children)
                     DFSRecursive(c);
             }
         }
 
         public void DFSRecursivePostorder()
         {
-            DFSRecursivePostorder(root);
+            DFSRecursivePostorder(this);
 
-            void DFSRecursivePostorder(Node node)
+            void DFSRecursivePostorder(Tree tree)
             {
-                foreach (var c in node.Children)
+                foreach (var c in tree._children)
                     DFSRecursivePostorder(c);
 
-                Console.WriteLine(node.Id);
+                Console.WriteLine(tree.Id);
             }
         }
 
         public void DFSRecursiveInorderBinary()
         {
-            DFSRecursiveInorderBinary(root);
+            DFSRecursiveInorderBinary(this);
 
             // This assumes only 2 children
-            void DFSRecursiveInorderBinary(Node node)
+            void DFSRecursiveInorderBinary(Tree tree)
             {
-                if (node.Children.Count > 2)
-                     throw new Exception("Not binary tree!");
+                if (tree._children.Count > 2)
+                    throw new Exception("Not binary tree!");
 
-                if (node.Children.Count > 0)
+                if (tree._children.Count > 0)
                 {
-                    DFSRecursiveInorderBinary(node.Children[0]);
-                    Console.WriteLine(node.Id);
-                    DFSRecursiveInorderBinary(node.Children[1]);
+                    DFSRecursiveInorderBinary(tree._children[0]);
+                    Console.WriteLine(tree.Id);
+                    DFSRecursiveInorderBinary(tree._children[1]);
                 }
                 else
-                    Console.WriteLine(node.Id);
+                    Console.WriteLine(tree.Id);
             }
         }
 
         public void DFSStack()
         {
-            var stack = new Stack<Node>();
-            stack.Push(root);
-            Node temp;
+            var stack = new Stack<Tree>();
+            stack.Push(this);
+            Tree temp;
 
             while (stack.Count != 0)
             {
                 Console.WriteLine(stack.Peek().Id);
                 temp = stack.Pop();
 
-                foreach (var c in temp.Children)
+                foreach (var c in temp._children)
                     stack.Push(c);
             }
         }
 
         public void BFSQueue()
         {
-            var queue = new Queue<Node>();
-            queue.Enqueue(root);
-            Node temp;
+            var queue = new Queue<Tree>();
+            queue.Enqueue(this);
+            Tree temp;
 
             while (queue.Count != 0)
             {
                 Console.WriteLine(queue.Peek().Id);
                 temp = queue.Dequeue();
 
-                foreach (var c in temp.Children)
+                foreach (var c in temp._children)
                     queue.Enqueue(c);
-            }
-        }
-
-        private void CreateAllChildren(Node node, int rowCount, int childrenCount)
-        {
-            if (rowCount <= 1)
-                return;
-
-            for (int i = 0; i < childrenCount; i++)
-            {
-                node.Children.Add(new Node(node.Id * 10 + i + 1));
-                CreateAllChildren(node.Children[i], rowCount - 1, childrenCount);
             }
         }
     }

--- a/chapters/tree_traversal/code/cs/Tree.cs
+++ b/chapters/tree_traversal/code/cs/Tree.cs
@@ -82,12 +82,11 @@ namespace TreeTraversal
         {
             var stack = new Stack<Tree>();
             stack.Push(this);
-            Tree temp;
 
             while (stack.Count != 0)
             {
                 Console.WriteLine(stack.Peek().Id);
-                temp = stack.Pop();
+                var temp = stack.Pop();
 
                 foreach (var c in temp._children)
                     stack.Push(c);
@@ -98,12 +97,11 @@ namespace TreeTraversal
         {
             var queue = new Queue<Tree>();
             queue.Enqueue(this);
-            Tree temp;
 
             while (queue.Count != 0)
             {
                 Console.WriteLine(queue.Peek().Id);
-                temp = queue.Dequeue();
+                var temp = queue.Dequeue();
 
                 foreach (var c in temp._children)
                     queue.Enqueue(c);

--- a/chapters/tree_traversal/tree_traversal.md
+++ b/chapters/tree_traversal/tree_traversal.md
@@ -144,7 +144,7 @@ In code, it looks like this:
 {% sample lang="cpp" %}
 [import:29-45, lang:"c_cpp"](code/c++/tree_example.cpp)
 {% sample lang="cs" %}
-[import:81-95, lang:"csharp"](code/cs/Tree.cs)
+[import:81-94, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:75-93, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -177,7 +177,7 @@ And this is exactly what Breadth-First Search (BFS) does! On top of that, it can
 {% sample lang="cpp" %}
 [import:47-61, lang:"c_cpp"](code/c++/tree_example.cpp)
 {% sample lang="cs" %}
-[import:97-111, lang:"csharp"](code/cs/Tree.cs)
+[import:96-109, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:95-113, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}

--- a/chapters/tree_traversal/tree_traversal.md
+++ b/chapters/tree_traversal/tree_traversal.md
@@ -8,7 +8,7 @@ Trees are naturally recursive data structures, and because of this, we cannot ac
 {% sample lang="cpp" %}
 [import:15-18, lang:"c_cpp"](code/c++/tree_example.cpp)
 {% sample lang="cs" %}
-[import:9-15, lang:"csharp"](code/cs/Tree.cs)
+[import:7-11, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:7-11, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -35,7 +35,7 @@ Because of this, the most straightforward way to traverse the tree might be recu
 {% sample lang="cpp" %}
 [import:20-27, lang:"c_cpp"](code/c++/tree_example.cpp)
 {% sample lang="cs" %}
-[import:25-36, lang:"csharp"](code/cs/Tree.cs)
+[import:34-45, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:37-45, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -71,7 +71,7 @@ Now, in this case the first element searched through is still the root of the tr
 This has not been implemented in your chosen language, so here is the Julia code
 [import:18-26, lang:"julia"](code/julia/Tree.jl)
 {% sample lang="cs" %}
-[import:38-49, lang:"csharp"](code/cs/Tree.cs)
+[import:47-58, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:47-53, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -103,7 +103,7 @@ In this case, the first node visited is at the bottom of the tree and moves up t
 This has not been implemented in your chosen language, so here is the Julia code
 [import:28-43, lang:"julia"](code/julia/Tree.jl)
 {% sample lang="cs" %}
-[import:51-70, lang:"csharp"](code/cs/Tree.cs)
+[import:60-79, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:55-73, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -144,7 +144,7 @@ In code, it looks like this:
 {% sample lang="cpp" %}
 [import:29-45, lang:"c_cpp"](code/c++/tree_example.cpp)
 {% sample lang="cs" %}
-[import:72-86, lang:"csharp"](code/cs/Tree.cs)
+[import:81-95, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:75-93, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -177,7 +177,7 @@ And this is exactly what Breadth-First Search (BFS) does! On top of that, it can
 {% sample lang="cpp" %}
 [import:47-61, lang:"c_cpp"](code/c++/tree_example.cpp)
 {% sample lang="cs" %}
-[import:88-102, lang:"csharp"](code/cs/Tree.cs)
+[import:97-111, lang:"csharp"](code/cs/Tree.cs)
 {% sample lang="c" %}
 [import:95-113, lang:"c_cpp"](code/c/tree_traversal.c)
 {% sample lang="java" %}
@@ -225,7 +225,7 @@ MainClass.java
 ### JavaScript
 [import, lang:"javascript"](code/javascript/tree.js)
 {% sample lang="py" %}
-### Python 
+### Python
 [import, lang:"python"](code/python/Tree_example.py)
 {% sample lang="scratch" %}
 ### Scratch


### PR DESCRIPTION
Restructure code by removing the `Node` class. Remove `CreateAllChildren` method and make the constructor do it instead.

This is applying the changes suggested @Gustorn in https://github.com/algorithm-archivists/algorithm-archive/pull/137 in discussion with @xam4lor .
The PR also removes the `CreateAllChildren` method and just makes the constructor recursive and do the creation.