### PR TITLE
Adding main() to Swift sorting algorithms

### DIFF
--- a/chapters/sorting_searching/bogo/code/swift/bogosort.swift
+++ b/chapters/sorting_searching/bogo/code/swift/bogosort.swift
@@ -37,3 +37,10 @@ func bogoSort(sortArray: inout [Int]) -> [Int] {
 
     return sortArray
 }
+
+func main() {
+    var testArray = [4,5,123,24,34,-5]
+    print(bogoSort(sortArray: &testArray))
+}
+
+main()

--- a/chapters/sorting_searching/bubble/bubble_sort.md
+++ b/chapters/sorting_searching/bubble/bubble_sort.md
@@ -35,7 +35,7 @@ This means that we need to go through the vector $$\mathcal{O}(n^2)$$ times with
 {% sample lang="racket" %}
 [import:5-19, lang:"racket"](code/racket/bubbleSort.rkt)
 {% sample lang="swift" %}
-[import:1-15, lang:"swift"](code/swift/bubblesort.swift)
+[import, lang:"swift"](code/swift/bubblesort.swift)
 {% endmethod %}
 
 ... And that's it for the simplest bubble sort method.


### PR DESCRIPTION
My current understanding is that code in the AAA is supposed to have a main() function to run the algorithm. So I updated the swift sorting algorithms to reflect this.

- Changed bubble_sort.md so main() is now shown
- Added main() to bogo sort