### PR TITLE
Improve readability of examples in verlet.cpp

### DIFF
--- a/chapters/algorithms/verlet_integration/code/c++/verlet.cpp
+++ b/chapters/algorithms/verlet_integration/code/c++/verlet.cpp
@@ -1,56 +1,51 @@
 #include <iostream>
 
 // Simple function for velocity-verlet
-void verlet(double pos, double acc, double dt) {
+double verlet(double pos, double acc, double dt) {
 
-  // Note that we are using a temp variable for the previous position
-  double prev_pos, temp_pos, time;
-  prev_pos = pos;
-  time = 0;
+  double prev_pos = pos;
+  double time = 0;
 
   while (pos > 0) {
     time += dt;
-    temp_pos = pos;
-    pos = pos * 2 - prev_pos + acc * dt * dt;
-    prev_pos = temp_pos;
+    double next_pos = pos * 2 - prev_pos + acc * dt * dt;
+    prev_pos = pos;
+    pos = next_pos;
   }
 
-  std::cout << time << '\n';
+  return time;
 }
 
 // Simple function for stormer-verlet
-void stormer_verlet(double pos, double acc, double dt) {
+double stormer_verlet(double pos, double acc, double dt) {
 
-  // Note that we are using a temp variable for the previous position
-  double prev_pos, temp_pos, time, vel;
-  prev_pos = pos;
-  vel = 0;
-  time = 0;
+  double prev_pos = pos;
+  double time = 0;
+  double vel = 0;
   while (pos > 0) {
     time += dt;
-    temp_pos = pos;
-    pos = pos * 2 - prev_pos + acc * dt * dt;
-    prev_pos = temp_pos;
+    double next_pos = pos * 2 - prev_pos + acc * dt * dt;
+    prev_pos = pos;
+    pos = next_pos;
 
     // The acceleration is constant, so the velocity is straightforward
     vel += acc * dt;
   }
 
-  std::cout << time << '\n';
+  return time;
 }
 
-void velocity_verlet(double pos, double acc, double dt) {
+double velocity_verlet(double pos, double acc, double dt) {
 
-  double time, vel;
-  vel = 0;
-  time = 0;
+  double time = 0;
+  double vel = 0;
   while (pos > 0) {
     time += dt;
     pos += vel * dt + 0.5 * acc * dt * dt;
     vel += acc * dt;
   }
 
-  std::cout << time << '\n';
+  return time;
 }
 
 int main() {
@@ -61,7 +56,7 @@ int main() {
   // For example, if your acceleration chages as a function of time, you might
   // need to also change the acceleration to be read into each of these
   // functions
-  verlet(5.0, -10, 0.01);
-  stormer_verlet(5.0, -10, 0.01);
-  velocity_verlet(5.0, -10, 0.01);
+  std::cout << verlet(5.0, -10, 0.01) << std::endl;
+  std::cout << stormer_verlet(5.0, -10, 0.01) << std::endl;
+  std::cout << velocity_verlet(5.0, -10, 0.01) << std::endl;
 }

--- a/chapters/algorithms/verlet_integration/verlet_integration.md
+++ b/chapters/algorithms/verlet_integration/verlet_integration.md
@@ -33,7 +33,7 @@ Here is what it looks like in code:
 {% sample lang="jl" %}
 [import:1-13, lang:"julia"](code/julia/verlet.jl)
 {% sample lang="cpp" %}
-[import:4-19, lang:"c_cpp"](code/c++/verlet.cpp)
+[import:4-17, lang:"c_cpp"](code/c++/verlet.cpp)
 {% sample lang="c" %}
 [import:3-16, lang:"c_cpp"](code/c/verlet.c)
 {% sample lang="java" %}
@@ -79,7 +79,7 @@ Here's what it looks like in code:
 {% sample lang="jl" %}
 [import:15-31, lang:"julia"](code/julia/verlet.jl)
 {% sample lang="cpp" %}
-[import:22-40, lang:"c_cpp"](code/c++/verlet.cpp)
+[import:20-36, lang:"c_cpp"](code/c++/verlet.cpp)
 {% sample lang="c" %}
 [import:18-33, lang:"c_cpp"](code/c/verlet.c)
 {% sample lang="java" %}
@@ -136,7 +136,7 @@ Here is the velocity Verlet method in code:
 {% sample lang="jl" %}
 [import:33-45, lang:"julia"](code/julia/verlet.jl)
 {% sample lang="cpp" %}
-[import:42-54, lang:"c_cpp"](code/c++/verlet.cpp)
+[import:38-49, lang:"c_cpp"](code/c++/verlet.cpp)
 {% sample lang="c" %}
 [import:35-46, lang:"c_cpp"](code/c/verlet.c)
 {% sample lang="java" %}


### PR DESCRIPTION
- make functions return time
- assign value to vars at declaration
- use next_pos var name instead of tmp_pos (delete comment)