### PR TITLE
Reimplemented Verlet Integration in Python

### DIFF
--- a/contents/verlet_integration/code/python/verlet.py
+++ b/contents/verlet_integration/code/python/verlet.py
@@ -4,7 +4,8 @@ def verlet(pos, acc, dt):
 
     while pos > 0:
         time += dt
-        prev_pos, pos = pos, pos * 2 - prev_pos + acc * dt * dt
+        next_pos = pos * 2 - prev_pos + acc * dt * dt
+        prev_pos, pos = pos, next_pos
 
     return time
 
@@ -15,7 +16,8 @@ def stormer_verlet(pos, acc, dt):
 
     while pos > 0:
         time += dt
-        prev_pos, pos = pos, pos * 2 - prev_pos + acc * dt * dt
+        next_pos = pos * 2 - prev_pos + acc * dt * dt
+        prev_pos, pos = pos, next_pos
         vel += acc * dt
 
     return time, vel

--- a/contents/verlet_integration/code/python/verlet.py
+++ b/contents/verlet_integration/code/python/verlet.py
@@ -1,72 +1,53 @@
-# KingFredrickVI
-class Ball:
+def verlet(pos, acc, dt):
+    prev_pos = pos
+    time = 0
 
-    def __init__(self, pos=0, vel=0, acc=0):
-        self.pos = pos
-        self.vel = vel
-        self.acc = acc
+    while pos > 0:
+        time += dt
+        prev_pos, pos = pos, pos * 2 - prev_pos + acc * dt * dt
 
+    return time
 
-class Simulation:
+def stormer_verlet(pos, acc, dt):
+    prev_pos = pos
+    time = 0
+    vel = 0
 
-    def __init__(self, obj, dt = 0.01):
-        self.obj = obj
-        self.dt = dt
-        self.prev_pos = self.obj.pos
+    while pos > 0:
+        time += dt
+        prev_pos, pos = pos, pos * 2 - prev_pos + acc * dt * dt
+        vel += acc * dt
 
-    def run(self):
-        self.time = 0
+    return time, vel
 
-        while self.obj.pos > 0:
-            self.time += self.dt
-            self.step()
+def velocity_verlet(pos, acc, dt):
+    time = 0
+    vel = 0
 
-    def step(self):
-        pass
+    while pos > 0:
+        time += dt
+        pos += vel * dt + 0.5 * acc * dt * dt
+        vel += acc * dt
 
-
-class Verlet(Simulation):
-
-    def step(self):
-        temp_pos = self.obj.pos
-        self.obj.pos = self.obj.pos * 2 - self.prev_pos + self.obj.acc * self.dt * self.dt
-        self.prev_pos = temp_pos
-
-class Stormer_Verlet(Simulation):
-
-    def step(self):
-        temp_pos = self.obj.pos
-        self.obj.pos = self.obj.pos * 2 - self.prev_pos + self.obj.acc * self.dt * self.dt
-        self.prev_pos = temp_pos
-
-        self.obj.vel += self.obj.acc * self.dt
-
-class Velocity_Verlet(Simulation):
-
-    def step(self):
-        self.obj.pos += self.obj.vel * self.dt + 0.5 * self.obj.acc * self.dt * self.dt
-        self.obj.vel += self.obj.acc * self.dt
-
+    return time, vel
 
 def main():
-    sim = Verlet(Ball(pos = 5.0, acc = -10))
-    sim.run()
+    time = verlet(5, -10, 0.01)
+    print("Verlet")
+    print("Time: {:.10f}".format(time))
+    print()
 
-    print("Verlet:", sim.time)
+    time, vel = stormer_verlet(5, -10, 0.01)
+    print("Stormer-Verlet")
+    print("Time: {:.10f}".format(time))
+    print("Velocity: {:.10f}".format(vel))
+    print()
 
-    sim = Stormer_Verlet(Ball(pos = 5.0, acc = -10))
-    sim.run()
+    time, vel = velocity_verlet(5, -10, 0.01)
+    print("Velocity Verlet")
+    print("Time: {:.10f}".format(time))
+    print("Velocity: {:.10f}".format(vel))
+    print()
 
-    print("Stormer Verlet:", sim.time)
-
-    sim = Velocity_Verlet(Ball(pos = 5.0, acc = -10))
-    sim.run()
-
-    print("Velocity Verlet:", sim.time)
-
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()
-
-
-

--- a/contents/verlet_integration/verlet_integration.md
+++ b/contents/verlet_integration/verlet_integration.md
@@ -39,7 +39,7 @@ Here is what it looks like in code:
 {% sample lang="java" %}
 [import:2-18, lang:"java"](code/java/verlet.java)
 {% sample lang="py" %}
-[import:28-33, lang:"python"](code/python/verlet.py)
+[import:1-9, lang:"python"](code/python/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in haskell, so here's Julia code:
 [import:1-13, lang:"julia"](code/julia/verlet.jl)
@@ -85,7 +85,7 @@ Here's what it looks like in code:
 {% sample lang="java" %}
 [import:21-40, lang:"java"](code/java/verlet.java)
 {% sample lang="py" %}
-[import:35-42, lang:"python"](code/python/verlet.py)
+[import:11-21, lang:"python"](code/python/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in scratch, so here's Julia code:
 [import:15-31, lang:"julia"](code/julia/verlet.jl)
@@ -142,7 +142,7 @@ Here is the velocity Verlet method in code:
 {% sample lang="java" %}
 [import:43-57, lang:"java"](code/java/verlet.java)
 {% sample lang="py" %}
-[import:44-48, lang:"python"](code/python/verlet.py)
+[import:23-32, lang:"python"](code/python/verlet.py)
 {% sample lang="hs" %}
 Unfortunately, this has not yet been implemented in haskell, so here's Julia code:
 [import:33-45, lang:"julia"](code/julia/verlet.jl)


### PR DESCRIPTION
During a recent discussion about #243 I noticed that the Python version of our Verlet Integration example code is vastly different from all other implementations. It creates a `Simulation` class and the 3 Verlet algorithms are classes that inherit from that `Simulation` class.

I changed the code to more closely match the other language implementations because I think that introducing classes and inheritance to a piece of example code like this is a bit excessive. Tell me what you think.