### PR TITLE
Small Change to C Implementation of Monte Carlo

### DIFF
--- a/chapters/algorithms/monte_carlo_integration/code/c/monte_carlo.c
+++ b/chapters/algorithms/monte_carlo_integration/code/c/monte_carlo.c
@@ -8,7 +8,8 @@ bool in_circle(double x, double y, double radius) {
     return x * x + y * y < radius * radius;
 }
 
-void monte_carlo(int samples, double radius) {
+void monte_carlo(int samples) {
+    double radius = 1.0;
     int count = 0;
 
     for (int i = 0; i < samples; ++i) {
@@ -29,7 +30,7 @@ void monte_carlo(int samples, double radius) {
 int main() {
     srand(time(NULL));
 
-    monte_carlo(1000000, 1.0);
+    monte_carlo(1000000);
 
     return 0;
 }


### PR DESCRIPTION
I was made aware in pull request #197 that there is a standard to not have radius as a parameter in the monte_carlo function. So I removed this parameter in the C implementation of Monte Carlo.