### PR TITLE
Several .md fixes

### DIFF
--- a/chapters/algorithms/cooley_tukey/cooley_tukey.md
+++ b/chapters/algorithms/cooley_tukey/cooley_tukey.md
@@ -202,7 +202,7 @@ I'll definitely come back to this at some point, so let me know what you liked a
 
 {% references %} {% endreferences %}
 
-### Example Code
+## Example Code
 
 To be clear, the example code this time will be complicated and requires the following functions:
 
@@ -219,22 +219,16 @@ Note: I implemented this in Julia because the code seems more straightforward in
 
 {% method %}
 {% sample lang="jl" %}
-### Julia
 [import, lang:"julia"](code/julia/fft.jl)
 {% sample lang="c" %}
-### C
 [import, lang:"c_cpp"](code/c/fft.c)
 {% sample lang="cpp" %}
-### C++
 [import, lang:"c_cpp"](code/c++/fft.cpp)
 {% sample lang="hs" %}
-### Haskell
 [import, lang:"haskell"](code/haskell/fft.hs)
 {% sample lang="py" %}
-### Python
 [import, lang:"python"](code/python/fft.py)
 {% sample lang="scratch" %}
-### Scratch
 Some rather impressive scratch code was submitted by Jie and can be found here: https://scratch.mit.edu/projects/37759604/#editor
 {% endmethod %}
 

--- a/chapters/algorithms/tree_traversal/tree_traversal.md
+++ b/chapters/algorithms/tree_traversal/tree_traversal.md
@@ -226,10 +226,8 @@ MainClass.java
     <img  class="center" src="code/scratch/scratch_tree.png" />
 </p>
 {% sample lang="rs"%}
-### Rust
 [import, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-### Haskell
 [import, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% endmethod %}
 

--- a/chapters/algorithms/verlet_integration/verlet_integration.md
+++ b/chapters/algorithms/verlet_integration/verlet_integration.md
@@ -188,19 +188,15 @@ Submitted by Jie
 </p>
 Link: [https://scratch.mit.edu/projects/173039394/](https://scratch.mit.edu/projects/173039394/)
 {% sample lang="matlab" %}
-### Matlab
 [import, lang:"matlab"](code/matlab/verlet.m)
 {% sample lang="LabVIEW" %}
-### LabVIEW
 Submitted by P. Mekhail
 <p>
     <img  class="center" src="code/labview/verlet_labview.png" />
 </p>
 {% sample lang="javascript" %}
-### JavaScript
 [import, lang:"javascript"](code/javascript/verlet.js)
 {% sample lang="rs" %}
-### Rust
 [import, lang:"rust"](code/rust/verlet.rs)
 {% endmethod %}
 


### PR DESCRIPTION
Realized I missed a handful of language headlines when attempting to remove them (#246). Also missed making one of the 'Example Code's the new standard size (#245). So I made the following changes:

- Removed a handful of language headlines
- fixed 'Example Code' size in cooley_tukey.md