### PR TITLE
Small .md Fixes for 'Example Code'

### DIFF
--- a/contents/euclidean_algorithm/euclidean_algorithm.md
+++ b/contents/euclidean_algorithm/euclidean_algorithm.md
@@ -89,7 +89,7 @@ EuclideanAlgorithm.cs
 Program.cs
 [import, lang="csharp"](code/csharp/Program.cs)
 {% sample lang="clj" %}
-[import 2-20, lang="clojure"](code/clojure/euclidean_example.clj)
+[import, lang="clojure"](code/clojure/euclidean_example.clj)
 {% sample lang="cpp" %}
 [import, lang="c_cpp"](code/c++/euclidean.cpp)
 {% sample lang="java" %}

--- a/contents/huffman_encoding/huffman_encoding.md
+++ b/contents/huffman_encoding/huffman_encoding.md
@@ -70,7 +70,7 @@ Program.cs
 {% sample lang="cpp" %}
 [import, lang:"c_cpp"](code/c++/huffman.cpp)
 {% sample lang="clj" %}
-[import 2-117, lang:"clojure"](code/clojure/huffman.clj)
+[import, lang:"clojure"](code/clojure/huffman.clj)
 {% sample lang="py" %}
 [import, lang:"python"](code/python/huffman.py)
 {% sample lang="js" %}


### PR DESCRIPTION
Found some attempted code cutoffs in the 'Example Code' section of two .md files. Although I don't think they actually do anything due to missing colons. 

- Removed attempted code cutoffs