### PR TITLE
Automatically build book and deploy to a repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,7 @@ before_script:
 
 script:
   - gitbook build . "${TRAVIS_BUILD_DIR}"/build
+  - |
+    if [[ "${TRAVIS_BRANCH}" == master ]]; then
+        bash "${TRAVIS_BUILD_DIR}"/tools/deploy/update_site_travis.bash
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+sudo: false
+
+language: node_js
+node_js:
+  - "4"
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install gitbook-cli -g
+  - gitbook install
+
+before_script:
+  - mkdir -p "${TRAVIS_BUILD_DIR}"/build
+
+script:
+  - gitbook build . "${TRAVIS_BUILD_DIR}"/build

--- a/tools/deploy/update_site_travis.bash
+++ b/tools/deploy/update_site_travis.bash
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# update_site_travis.bash: Update a GitHub repo with the book build
+# products.
+
+set -o errexit
+
+# Required environment variables:
+# - DOCS_BRANCH_NAME: name of the remote branch serving the book
+# - GH_REPO_NAME: name of the remote repo
+# - GH_USER: name of the remote repo's owner
+# - GH_TOKEN: [secret] Personal Access Token
+
+if [ -z ${DOCS_BRANCH_NAME+x} ]; then
+    echo "\$DOCS_BRANCH_NAME is not set!"
+    exit 1
+elif [ -z ${GH_REPO_NAME+x} ]; then
+    echo "\$GH_REPO_NAME is not set!"
+    exit 1
+elif [ -z ${GH_TOKEN+x} ]; then
+    echo "\$GH_TOKEN is not set!"
+    exit 1
+elif [ -z ${GH_USER+x} ]; then
+    echo "\$GH_USER is not set!"
+    exit 1
+fi
+
+git config user.name "Travis CI User"
+git config user.email "travis@travis-ci.org"
+
+GH_REPO_REF="github.com/${GH_USER}/${GH_REPO_NAME}.git"
+
+# Assume the book has already been built, and was moved to `build/`
+# inside the same directory as this script.
+
+if [ -d build ]; then
+    echo "Cloning the website repo..."
+    git clone -b $DOCS_BRANCH_NAME https://git@${GH_REPO_REF}
+    rm -rf ./"${GH_REPO_NAME}"/*
+    cp -a ./build/* ./"${GH_REPO_NAME}"
+    pushd ./"${GH_REPO_NAME}"
+    echo "Adding changes..."
+    git add --all
+    echo "Committing..."
+    # This will return 1 if there are no changes, which should not
+    # result in failure.
+    git commit \
+        -m "Deploy book to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" \
+        -m "Commit: ${TRAVIS_COMMIT}" || ret=$?
+    git push --force "https://${GH_TOKEN}@${GH_REPO_REF}" > /dev/null 2>&1
+    popd
+else
+    echo "" >&2
+    echo "Warning: The book wasn't found found!" >&2
+    echo "Warning: Not going to push the book to GitHub!" >&2
+    exit 1
+fi

--- a/tools/deploy/update_site_travis.bash
+++ b/tools/deploy/update_site_travis.bash
@@ -8,20 +8,23 @@ set -o errexit
 # Required environment variables:
 # - DOCS_BRANCH_NAME: name of the remote branch serving the book
 # - GH_REPO_NAME: name of the remote repo
-# - GH_USER: name of the remote repo's owner
 # - GH_TOKEN: [secret] Personal Access Token
+# - GH_USER: name of the remote repo's owner
+
+bold=$(tput bold)
+normal=$(tput sgr0)
 
 if [ -z ${DOCS_BRANCH_NAME+x} ]; then
-    echo "\$DOCS_BRANCH_NAME is not set!"
+    echo "${bold}\$DOCS_BRANCH_NAME is not set!${normal}"
     exit 1
 elif [ -z ${GH_REPO_NAME+x} ]; then
-    echo "\$GH_REPO_NAME is not set!"
+    echo "${bold}\$GH_REPO_NAME is not set!${normal}"
     exit 1
 elif [ -z ${GH_TOKEN+x} ]; then
-    echo "\$GH_TOKEN is not set!"
+    echo "${bold}\$GH_TOKEN is not set!${normal}"
     exit 1
 elif [ -z ${GH_USER+x} ]; then
-    echo "\$GH_USER is not set!"
+    echo "${bold}\$GH_USER is not set!${normal}"
     exit 1
 fi
 
@@ -34,14 +37,14 @@ GH_REPO_REF="github.com/${GH_USER}/${GH_REPO_NAME}.git"
 # inside the same directory as this script.
 
 if [ -d build ]; then
-    echo "Cloning the website repo..."
+    echo "${bold}Cloning the website repo...${normal}"
     git clone -b $DOCS_BRANCH_NAME https://git@${GH_REPO_REF}
     rm -rf ./"${GH_REPO_NAME}"/*
     cp -a ./build/* ./"${GH_REPO_NAME}"
     pushd ./"${GH_REPO_NAME}"
-    echo "Adding changes..."
+    echo "${bold}Adding changes...${normal}"
     git add --all
-    echo "Committing..."
+    echo "${bold}Committing...${normal}"
     # This will return 1 if there are no changes, which should not
     # result in failure.
     git commit \
@@ -51,7 +54,7 @@ if [ -d build ]; then
     popd
 else
     echo "" >&2
-    echo "Warning: The book wasn't found found!" >&2
-    echo "Warning: Not going to push the book to GitHub!" >&2
+    echo "${bold}Warning: The book wasn't found!${normal}" >&2
+    echo "${bold}Warning: Not going to push the book to GitHub!${normal}" >&2
     exit 1
 fi


### PR DESCRIPTION
If you turn on Travis continuous integration (free), you can test code in a remote container and do other neat stuff, like deploy documentation...or a book.

1. "Test" the repository by making sure the book builds. CI runs automatically at every update for every PR, and every merge to master. https://github.com/algorithm-archivists/algorithm-archive/pull/281 would have been caught before merging.
2. If the book builds successfully, and this is a merge to master, push the book to a remote repo. No more need to update manually.

1 can exist without 2, so if you don't like it, that part can be removed. The results for my build are at https://travis-ci.com/berquist/algorithm-archive. Signing up for Travis CI is relatively easy, but if you want point 2, here is the extra work required. Everything below here is about automatically deploying the book.

1. On GitHub, request a Personal Access Token, with `repo` scope. Instructions [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/), but can be done entirely from the browser. Keep the token somewhere safe, because you can't look at it again, and do _not_ give it to anyone else.

2. The deploy script requires that some environment variables be entered into Travis. At your Travis repo page,
![screenshot from 2018-07-20 23-58-02](https://user-images.githubusercontent.com/727571/43031888-ea813ed4-8c78-11e8-89ee-af646837c621.png)
click "More options" then "Settings", then scroll down. These are mine for testing. The repo is https://github.com/berquist/algorithm_archive_build/commits/master and the website is https://berquist.github.io/algorithm_archive_build/.
![screenshot from 2018-07-20 23-58-32](https://user-images.githubusercontent.com/727571/43031900-1a5a7df0-8c79-11e8-8532-316b1b08dc37.png)
Your non-secret environment variables would be
* `GH_USER`: `algorithm-archivists`
* `GH_REPO_NAME`: `algorithm-archivists.github.io`
* `DOCS_BRANCH_NAME`: `master`
* `GH_TOKEN`: copy-paste the PAT here, and don't display it.