### PR TITLE
Improving Euclidean Algorithm in Swift

### DIFF
--- a/contents/euclidean_algorithm/code/swift/euclidean_algorithm.swift
+++ b/contents/euclidean_algorithm/code/swift/euclidean_algorithm.swift
@@ -1,39 +1,34 @@
 func euclidSub(a: Int, b: Int) -> Int {
-    var A = abs(a)
-    var B = abs(b)
+    var a = abs(a)
+    var b = abs(b)
     
-    while (A != B) {
-        if (A > B) {
-            A -= B
+    while (a != b) {
+        if (a > b) {
+            a -= b
         } else {
-            B -= A
+            b -= a
         }
     }
     
-    return A
+    return a
 }
-
 
 func euclidMod(a: Int, b: Int) -> Int {
-    var A = abs(a);
-    var B = abs(b);
+    var a = abs(a);
+    var b = abs(b);
     
-    while (B != 0) {
-        let temp = B
-        B = A % B
-        A = temp
+    while (b != 0) {
+        let temp = b
+        b = a % b
+        a = temp
     }
     
-    return A
+    return a
 }
-
-
-
 
 func main() {
     print(euclidMod(a: 64 * 67, b: 64 * 81))
     print(euclidSub(a: 128 * 12, b: 128 * 77))
 }
-
 
 main()

--- a/contents/euclidean_algorithm/euclidean_algorithm.md
+++ b/contents/euclidean_algorithm/euclidean_algorithm.md
@@ -28,7 +28,7 @@ The algorithm is a simple way to find the *greatest common divisor* (GCD) of two
 {% sample lang="go" %}
 [import:25-38, lang="golang"](code/go/euclidean.go)
 {% sample lang="swift" %}
-[import:1-15, lang="swift"](code/swift/euclidean_algorithm.swift)
+[import:1-14, lang="swift"](code/swift/euclidean_algorithm.swift)
 {% sample lang="matlab" %}
 [import:3-17, lang="matlab"](code/matlab/euclidean.m)
 {% endmethod %}
@@ -65,7 +65,7 @@ Modern implementations, though, often use the modulus operator (%) like so
 {% sample lang="go" %}
 [import:14-23, lang="golang"](code/go/euclidean.go)
 {% sample lang="swift" %}
-[import:17-29, lang="swift"](code/swift/euclidean_algorithm.swift)
+[import:16-27, lang="swift"](code/swift/euclidean_algorithm.swift)
 {% sample lang="matlab" %}
 [import:19-31, lang="matlab"](code/matlab/euclidean.m)
 {% endmethod %}


### PR DESCRIPTION
In Swift parameters are immutable. The way this is typically dealt with is to create a local mutable version of the parameter with the same name. I had essentially done this but had not used the same name as the parameter. 

So I replaced all 'A'/'B's in the code with 'a'/'b's. This helps the code to both be cleaner and more in line with the typical Swift style.

I also removed some whitespace.