### PR TITLE
Add Monte Carlo Integration in C#

### DIFF
--- a/contents/monte_carlo_integration/code/csharp/Circle.cs
+++ b/contents/monte_carlo_integration/code/csharp/Circle.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace MonteCarloIntegration
+{
+    public struct Point
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+
+        public Point(double x, double y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
+    }
+
+    public class Circle
+    {
+        public double Radius { get; private set; }
+
+        public Circle(double radius) => this.Radius = Math.Abs(radius);
+
+        public bool IsInMe(Point point) => point.X * point.X + point.Y * point.Y < Radius * Radius;
+    }
+}

--- a/contents/monte_carlo_integration/code/csharp/Circle.cs
+++ b/contents/monte_carlo_integration/code/csharp/Circle.cs
@@ -20,6 +20,6 @@ namespace MonteCarloIntegration
 
         public Circle(double radius) => this.Radius = Math.Abs(radius);
 
-        public bool IsInMe(Point point) => point.X * point.X + point.Y * point.Y < Radius * Radius;
+        public bool IsInMe(Point point) => Math.Pow(point.X, 2) + Math.Pow(point.Y, 2) < Math.Pow(Radius, 2);
     }
 }

--- a/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
+++ b/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace MonteCarloIntegration
+{
+    public class MonteCarlo
+    {
+        public struct RunOutput
+        {
+            public double PiEstimate { get; private set; }
+            public double Error { get; private set; }
+
+            public RunOutput(double piEstimate, double error)
+            {
+                this.PiEstimate = piEstimate;
+                this.Error = error;
+            }
+        }
+
+        public RunOutput Run(int samples)
+        {
+            var circle = new Circle(1.0);
+            var count = 0;
+            var random = new Random();
+
+            for (int i = 0; i < samples; i++)
+            {
+                var point = new Point(random.NextDouble(), random.NextDouble());
+                if (circle.IsInMe(point))
+                    count++;
+            }
+
+            var piEstimate = 4.0 * count / samples;
+            var error = Math.Abs(Math.PI - piEstimate);
+            return new RunOutput(piEstimate, error);
+        }
+    }
+}

--- a/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
+++ b/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
@@ -4,19 +4,19 @@ namespace MonteCarloIntegration
 {
     public class MonteCarlo
     {
-        public struct RunOutput
+        public struct PiEstimate
         {
-            public double PiEstimate { get; private set; }
+            public double Estimate { get; private set; }
             public double Error { get; private set; }
 
-            public RunOutput(double piEstimate, double error)
+            public PiEstimate(double estimate, double error)
             {
-                this.PiEstimate = piEstimate;
+                this.Estimate = estimate;
                 this.Error = error;
             }
         }
 
-        public RunOutput Run(int samples)
+        public PiEstimate Run(int samples)
         {
             var circle = new Circle(1.0);
             var count = 0;
@@ -31,7 +31,7 @@ namespace MonteCarloIntegration
 
             var piEstimate = 4.0 * count / samples;
             var error = Math.Abs(Math.PI - piEstimate);
-            return new RunOutput(piEstimate, error);
+            return new PiEstimate(piEstimate, error);
         }
     }
 }

--- a/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
+++ b/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
@@ -7,12 +7,12 @@ namespace MonteCarloIntegration
         public struct PiEstimate
         {
             public double Estimate { get; private set; }
-            public double Error { get; private set; }
+            public double PercentError { get; private set; }
 
-            public PiEstimate(double estimate, double error)
+            public PiEstimate(double estimate, double percentError)
             {
                 this.Estimate = estimate;
-                this.Error = error;
+                this.PercentError = percentError;
             }
         }
 
@@ -30,8 +30,8 @@ namespace MonteCarloIntegration
             }
 
             var piEstimate = 4.0 * count / samples;
-            var error = Math.Abs(Math.PI - piEstimate);
-            return new PiEstimate(piEstimate, error);
+            var percentError = (piEstimate - Math.PI) / Math.PI * 100;
+            return new PiEstimate(piEstimate, percentError);
         }
     }
 }

--- a/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
+++ b/contents/monte_carlo_integration/code/csharp/MonteCarlo.cs
@@ -4,19 +4,7 @@ namespace MonteCarloIntegration
 {
     public class MonteCarlo
     {
-        public struct PiEstimate
-        {
-            public double Estimate { get; private set; }
-            public double PercentError { get; private set; }
-
-            public PiEstimate(double estimate, double percentError)
-            {
-                this.Estimate = estimate;
-                this.PercentError = percentError;
-            }
-        }
-
-        public PiEstimate Run(int samples)
+        public double Run(int samples)
         {
             var circle = new Circle(1.0);
             var count = 0;
@@ -29,9 +17,7 @@ namespace MonteCarloIntegration
                     count++;
             }
 
-            var piEstimate = 4.0 * count / samples;
-            var percentError = (piEstimate - Math.PI) / Math.PI * 100;
-            return new PiEstimate(piEstimate, percentError);
+            return 4.0 * count / samples;
         }
     }
 }

--- a/contents/monte_carlo_integration/code/csharp/Program.cs
+++ b/contents/monte_carlo_integration/code/csharp/Program.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace MonteCarloIntegration
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var monteCarlo = new MonteCarlo();
+            System.Console.WriteLine("Running with 10.000.000 samples.");
+            var output = monteCarlo.Run(10000000);
+            System.Console.WriteLine($"The estimate of pi is: {output.PiEstimate}");
+            System.Console.WriteLine($"The error is: {output.Error}");
+
+            System.Console.WriteLine("How many samples should be used?");
+            var samples = 0;
+            if (!int.TryParse(System.Console.ReadLine(), out samples))
+                throw new System.Exception("You didn't input a valid number.");
+            samples = Math.Abs(samples);
+            System.Console.WriteLine($"Running with {samples} samples.");
+            output = monteCarlo.Run(samples);
+            System.Console.WriteLine($"The estimate of pi is: {output.PiEstimate}");
+            System.Console.WriteLine($"The error is: {output.Error}");
+        }
+    }
+}

--- a/contents/monte_carlo_integration/code/csharp/Program.cs
+++ b/contents/monte_carlo_integration/code/csharp/Program.cs
@@ -7,20 +7,10 @@ namespace MonteCarloIntegration
         static void Main(string[] args)
         {
             var monteCarlo = new MonteCarlo();
-            System.Console.WriteLine("Running with 10.000.000 samples.");
+            System.Console.WriteLine("Running with 10,000,000 samples.");
             var piEstimate = monteCarlo.Run(10000000);
             System.Console.WriteLine($"The estimate of pi is: {piEstimate.Estimate}");
-            System.Console.WriteLine($"The error is: {piEstimate.Error}");
-
-            System.Console.WriteLine("How many samples should be used?");
-            var samples = 0;
-            if (!int.TryParse(System.Console.ReadLine(), out samples))
-                throw new System.Exception("You didn't input a valid number.");
-            samples = Math.Abs(samples);
-            System.Console.WriteLine($"Running with {samples} samples.");
-            piEstimate = monteCarlo.Run(samples);
-            System.Console.WriteLine($"The estimate of pi is: {piEstimate.Estimate}");
-            System.Console.WriteLine($"The error is: {piEstimate.Error}");
+            System.Console.WriteLine($"The percent error is: {piEstimate.PercentError}%");
         }
     }
 }

--- a/contents/monte_carlo_integration/code/csharp/Program.cs
+++ b/contents/monte_carlo_integration/code/csharp/Program.cs
@@ -8,9 +8,9 @@ namespace MonteCarloIntegration
         {
             var monteCarlo = new MonteCarlo();
             System.Console.WriteLine("Running with 10.000.000 samples.");
-            var output = monteCarlo.Run(10000000);
-            System.Console.WriteLine($"The estimate of pi is: {output.PiEstimate}");
-            System.Console.WriteLine($"The error is: {output.Error}");
+            var piEstimate = monteCarlo.Run(10000000);
+            System.Console.WriteLine($"The estimate of pi is: {piEstimate.Estimate}");
+            System.Console.WriteLine($"The error is: {piEstimate.Error}");
 
             System.Console.WriteLine("How many samples should be used?");
             var samples = 0;
@@ -18,9 +18,9 @@ namespace MonteCarloIntegration
                 throw new System.Exception("You didn't input a valid number.");
             samples = Math.Abs(samples);
             System.Console.WriteLine($"Running with {samples} samples.");
-            output = monteCarlo.Run(samples);
-            System.Console.WriteLine($"The estimate of pi is: {output.PiEstimate}");
-            System.Console.WriteLine($"The error is: {output.Error}");
+            piEstimate = monteCarlo.Run(samples);
+            System.Console.WriteLine($"The estimate of pi is: {piEstimate.Estimate}");
+            System.Console.WriteLine($"The error is: {piEstimate.Error}");
         }
     }
 }

--- a/contents/monte_carlo_integration/code/csharp/Program.cs
+++ b/contents/monte_carlo_integration/code/csharp/Program.cs
@@ -9,8 +9,8 @@ namespace MonteCarloIntegration
             var monteCarlo = new MonteCarlo();
             System.Console.WriteLine("Running with 10,000,000 samples.");
             var piEstimate = monteCarlo.Run(10000000);
-            System.Console.WriteLine($"The estimate of pi is: {piEstimate.Estimate}");
-            System.Console.WriteLine($"The percent error is: {piEstimate.PercentError}%");
+            System.Console.WriteLine($"The estimate of pi is: {piEstimate}");
+            System.Console.WriteLine($"The percent error is: {Math.Abs(piEstimate - Math.PI) / Math.PI * 100}%");
         }
     }
 }

--- a/contents/monte_carlo_integration/monte_carlo_integration.md
+++ b/contents/monte_carlo_integration/monte_carlo_integration.md
@@ -61,6 +61,8 @@ each point is tested to see whether it's in the circle or not:
 [import:15-17, lang:"swift"](code/swift/monte_carlo.swift)
 {% sample lang="py" %}
 [import:5-7, lang:"python"](code/python/monte_carlo.py)
+{% sample lang="cs" %}
+[import:23-23, lang:"csharp"](code/csharp/Circle.cs)
 {% endmethod %}
 
 If it's in the circle, we increase an internal count by one, and in the end,
@@ -116,6 +118,13 @@ Feel free to submit your version via pull request, and thanks for reading!
 [import, lang:"swift"](code/swift/monte_carlo.swift)
 {% sample lang="py" %}
 [import, lang:"python"](code/python/monte_carlo.py)
+{% sample lang="cs" %}
+MonteCarlo.cs
+[import, lang:"csharp"](code/csharp/MonteCarlo.cs)
+Circle.cs
+[import, lang:"csharp"](code/csharp/Circle.cs)
+Program.cs
+[import, lang:"csharp"](code/csharp/Program.cs)
 {% endmethod %}
 
 


### PR DESCRIPTION
Since [this PR](https://github.com/algorithm-archivists/algorithm-archive/pull/239) is dead, I wrote it myself.

- [x] Use`Math.Pow` instead of `point.X * point.X`.
- [x] Make the error a percentage.
- [x] Use `10,000,000` instead of `10.000.000` for the console output.
- [ ] Calculate the percent error in Main.