### PR TITLE
Added mathjax reference on algorithm-archivists/plugin-mathjax

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
   "gitbook": "3.x.x",
   "plugins": [
     "fontsettings",
-    "mathjax",
+    "mathjax@https://github.com/algorithm-archivists/plugin-mathjax",
     "bibtex-cite",
     "creativecommons",
     "wordcount",
@@ -15,6 +15,9 @@
     "maxIndexSize": 1000000000
   },
   "pluginsConfig": {
+    "mathjax":{
+      "version": "2.6.1"
+    },
     "include-codeblock": {
       "fixlang": true,
       "unindent": true


### PR DESCRIPTION
This is applicable if

- [x] https://github.com/algorithm-archivists/plugin-mathjax/pull/1 is merged
- [ ] Check locally if dependency on updated plugin is correctly download in ```gitbook install```

I set version which is currently as fallback **2.6.1** but it's possible use any version, just changing **book.json** for future :)