### PR TITLE
Use Travis CI to test the book build and then deploy it to the site, take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: false
+
+language: node_js
+node_js:
+  - "4"
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install gitbook-cli -g
+  - gitbook install
+
+before_script:
+  - mkdir -p "${TRAVIS_BUILD_DIR}"/build
+
+script:
+  - gitbook build . "${TRAVIS_BUILD_DIR}"/build
+  - env | sort
+  - |
+    if [[ "${TRAVIS_BRANCH}" == master && "${TRAVIS_PULL_REQUEST}" == false ]]; then
+        # Commits to master that are not pull requests, that is, only
+        # actual addition of code to master, should deploy the book to
+        # the site.
+        bash "${TRAVIS_BUILD_DIR}"/tools/deploy/update_site_travis.bash
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: node_js
 node_js:
   - "4"
 
-cache:
-  directories:
-    - node_modules
+# cache:
+#   directories:
+#     - node_modules
 
 install:
   - npm install gitbook-cli -g

--- a/tools/deploy/update_site_travis.bash
+++ b/tools/deploy/update_site_travis.bash
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# update_site_travis.bash: Update a GitHub repo with the book build
+# products.
+
+set -o errexit
+
+# Required environment variables:
+# - DOCS_BRANCH_NAME: name of the remote branch serving the book
+# - DOCS_REPO_NAME: name of the remote repo
+# - DOCS_REPO_OWNER: name of the remote repo's owner
+# - GH_TOKEN: [secret] Personal Access Token
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if [ -z ${DOCS_BRANCH_NAME+x} ]; then
+    echo "${bold}\$DOCS_BRANCH_NAME is not set!${normal}"
+    exit 1
+elif [ -z ${DOCS_REPO_NAME+x} ]; then
+    echo "${bold}\$DOCS_REPO_NAME is not set!${normal}"
+    exit 1
+elif [ -z ${DOCS_REPO_OWNER+x} ]; then
+    echo "${bold}\$DOCS_REPO_OWNER is not set!${normal}"
+    exit 1
+elif [ -z ${GH_TOKEN+x} ]; then
+    echo "${bold}\$GH_TOKEN is not set!${normal}"
+    exit 1
+fi
+
+git config user.name "Travis CI User"
+git config user.email "travis@travis-ci.org"
+
+GH_REPO_REF="github.com/${DOCS_REPO_OWNER}/${DOCS_REPO_NAME}.git"
+
+# Assume the book has already been built, and was moved to `build/`
+# inside the same directory as this script.
+
+if [ -d build ]; then
+    echo "${bold}Cloning the website repo...${normal}"
+    git clone -b $DOCS_BRANCH_NAME https://git@${GH_REPO_REF}
+    rm -rf ./"${DOCS_REPO_NAME}"/*
+    cp -a ./build/* ./"${DOCS_REPO_NAME}"
+    pushd ./"${DOCS_REPO_NAME}"
+    # echo "www.algorithm-archive.org" > CNAME
+    echo "${bold}Adding changes...${normal}"
+    git add --all
+    echo "${bold}Committing...${normal}"
+    # This will return 1 if there are no changes, which should not
+    # result in failure.
+    git commit \
+        -m "Deploy book to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" \
+        -m "Commit: ${TRAVIS_COMMIT}" || ret=$?
+    git push "https://${GH_TOKEN}@${GH_REPO_REF}" > /dev/null 2>&1
+    popd
+else
+    echo "" >&2
+    echo "${bold}Warning: The book wasn't found!${normal}" >&2
+    echo "${bold}Warning: Not going to push the book to GitHub!${normal}" >&2
+    exit 1
+fi

--- a/tools/deploy/update_site_travis.bash
+++ b/tools/deploy/update_site_travis.bash
@@ -38,11 +38,11 @@ GH_REPO_REF="github.com/${DOCS_REPO_OWNER}/${DOCS_REPO_NAME}.git"
 
 if [ -d build ]; then
     echo "${bold}Cloning the website repo...${normal}"
-    git clone -b $DOCS_BRANCH_NAME https://git@${GH_REPO_REF}
+    git clone -b "${DOCS_BRANCH_NAME}" https://git@"${GH_REPO_REF}"
     rm -rf ./"${DOCS_REPO_NAME}"/*
     cp -a ./build/* ./"${DOCS_REPO_NAME}"
     pushd ./"${DOCS_REPO_NAME}"
-    # echo "www.algorithm-archive.org" > CNAME
+    echo "www.algorithm-archive.org" > CNAME
     echo "${bold}Adding changes...${normal}"
     git add --all
     echo "${bold}Committing...${normal}"
@@ -51,7 +51,7 @@ if [ -d build ]; then
     git commit \
         -m "Deploy book to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" \
         -m "Commit: ${TRAVIS_COMMIT}" || ret=$?
-    git push "https://${GH_TOKEN}@${GH_REPO_REF}" > /dev/null 2>&1
+    git push "https://${GH_TOKEN}@${GH_REPO_REF}"
     popd
 else
     echo "" >&2


### PR DESCRIPTION
Continuation of https://github.com/algorithm-archivists/algorithm-archive/pull/284.

Don't merge this yet, because things need to be added.

The last PR failed in three ways:

1. The site went down because the CNAME for custom domain redirection was not present. After checking the log ([which I saved](https://github.com/algorithm-archivists/algorithm-archive/files/2239118/409399060.txt)), if you're curious, I noticed that there are several other files present in algorithm-archivists.github.io that do _not_ come from either the main repo or building the book. These can persist because `update_site.sh` only copies files over, rather than wipe and move. This is personal preference, but I think the website repo should be entirely reproducible from the main repo via this script. You can see the difference by comparing [your website repo](https://github.com/algorithm-archivists/algorithm-archivists.github.io) with [mine](https://github.com/berquist/algorithm_archive_build). Let me know which path you'd rather take, and I'll either need to add those files to the main repo and have them copy over during deploy, or have the deploy copy the build rather than wipe the book repo.

2. The guard for when the book should be deployed was wrong. Once the initial PR was merged, every Travis `pull_request` build (see below) was going to try deploy. This is before the merge actually happens. I don't think Travis would continue to this step if the build failed earlier, but it's still wrong.

3. A bunch of files got deleted. I still don't know how this happened, because I think they should have been present in the book build. I don't think they were extra files left over from before the flattening, either.

---

For reference, and because I didn't understand it for a while, there are two kinds of Travis builds:

1. `push`:
    - Under the status dialog, this is called `Travis CI - Branch` and `continuous-integration/travis-ci/push`.
    - "This is a normal build for the <branch-name> branch. You should be able to reproduce it by checking out the branch locally."
    - What it does is test the branch as-is. By default, this will run for _everyone_ who has a fork of the main repo every time they push to their own fork.

2. `pull_request`:
    - Under the status dialog, this is called `Travis CI - Pull Request` and `continuous-integration/travis-ci/pr`.
    - "This is a pull request build. It is running a build against the merge commit, after merging <pull-request-name>. Any changes that have been made to the master branch before the build ran are also included."
    - What is does is it simulates merge specified by the PR, then runs the Travis config. This only runs after creating a pull request.

The reason each type of CI run appears twice is that the former leads to the pretty GitHub summary, and the latter leads to the actual Travis log.

The config is now set up so that only `push` commits to master will deploy to algorithm-archivists.github.io. I checked, and this works in all cases: when there's a merge commit, a rebase and FF merge, a squash and merge, or a regular commit. _Any_ time the history of master is updated, the book will be built and deployed.

---

Note that I changed the names of some environment variables you must set in Travis to be more explicit. Hopefully things are clearer now.