### PR TITLE
Small Spelling Fix for Tree Traversal in Java

### DIFF
--- a/contents/tree_traversal/code/java/MainClass.java
+++ b/contents/tree_traversal/code/java/MainClass.java
@@ -22,7 +22,7 @@ public class MainClass {
         tree.dfsRecursiveInOrderBinary();
 
         tree = new Tree(3, 2);
-        System.out.println("Using in-order binary recursive DFS : (suceed)");
+        System.out.println("Using in-order binary recursive DFS : (succeed)");
         tree.dfsRecursiveInOrderBinary();
 
 


### PR DESCRIPTION
Added a single letter
- Changed 'suceed' to 'succeed'