### PR TITLE
Fix typo in Rust tree traversal

### DIFF
--- a/contents/tree_traversal/code/rust/tree.rs
+++ b/contents/tree_traversal/code/rust/tree.rs
@@ -16,7 +16,7 @@ fn dfs_recursive(n: &Node) {
 
 fn dfs_recursive_postorder(n: &Node) {
     for child in &n.children {
-        dfs_recursive(child);
+        dfs_recursive_postorder(child);
     }
 
     println!("{}", n.value);
@@ -69,15 +69,16 @@ fn create_tree(num_row: u64, num_child: u64) -> Node {
 }
 
 fn main() {
-    let root = create_tree(3,2);
+    let root = create_tree(2, 3);
     println!("Recursive DFS:");
     dfs_recursive(&root);
     println!("Stack DFS:");
     dfs_stack(&root);
     println!("Queue BFS:");
     bfs_queue(&root);
-    println!("Recursive PostOrder DFS: ");
+    println!("Recursive post-order DFS:");
     dfs_recursive_postorder(&root);
-    println!("Recursive DFS BTree:");
-    dfs_recursive_inorder_btree(&root);
+    println!("Recursive in-order DFS BTree:");
+    let root_binary = create_tree(3, 2);
+    dfs_recursive_inorder_btree(&root_binary);
 }


### PR DESCRIPTION
Creating trees is also more consistent with the Julia implementation.