### PR TITLE
Update Julia bogosort

### DIFF
--- a/contents/bogo_sort/bogo_sort.md
+++ b/contents/bogo_sort/bogo_sort.md
@@ -14,7 +14,7 @@ In code, it looks something like this:
 
 {% method %}
 {% sample lang="jl" %}
-[import:10-14, lang:"julia"](code/julia/bogo.jl)
+[import:12-16, lang:"julia"](code/julia/bogo.jl)
 {% sample lang="cs" %}
 [import:9-15, lang:"csharp"](code/csharp/BogoSort.cs)
 {% sample lang="clj" %}

--- a/contents/bogo_sort/code/julia/bogo.jl
+++ b/contents/bogo_sort/code/julia/bogo.jl
@@ -1,6 +1,8 @@
+using Random
+
 function is_sorted(a::Vector{Float64})
     for i = 1:length(a)-1
-        if (a[i+1] > a[i])
+        if (a[i] > a[i + 1])
             return false
         end
     end
@@ -14,7 +16,7 @@ function bogo_sort(a::Vector{Float64})
 end
 
 function main()
-    a = [1., 3, 2,4]
+    a = [1, 3, 2, 4]
     bogo_sort(a)
     println(a)
 end


### PR DESCRIPTION
- bug that caused sorting order to be reversed
- spaces after commas
- Julia v1 has shuffle! in the Random package. I don't know how long the transitional period to 1.0 is, but is it a problem if this doesn't work with < 1.0?