### PR TITLE
Updating Bogo Sort in Swift 4.1 to Swift 4.2

### DIFF
--- a/contents/bogo_sort/bogo_sort.md
+++ b/contents/bogo_sort/bogo_sort.md
@@ -36,7 +36,7 @@ In code, it looks something like this:
 {% sample lang="rs" %}
 [import:16-20, lang:"rust"](code/rust/bogosort.rs)
 {% sample lang="swift" %}
-[import:25-31, lang:"swift"](code/swift/bogosort.swift)
+[import:13-19, lang:"swift"](code/swift/bogosort.swift)
 {% sample lang="php" %}
 [import:11-16, lang:"php"](code/php/bogo_sort.php)
 {% sample lang="nim" %}

--- a/contents/bogo_sort/code/swift/bogosort.swift
+++ b/contents/bogo_sort/code/swift/bogosort.swift
@@ -6,27 +6,15 @@ func isSorted(inputArray: [Int]) -> Bool {
             return false
         }
     }
-    
+
     return true
-}
-
-func shuffle(inputArray: inout [Int]) -> [Int] {
-    var shuffledArray = [Int]()
-
-    for _ in 0..<inputArray.count {
-        let rand = Int(arc4random_uniform(UInt32(inputArray.count)))
-        shuffledArray.append(inputArray[rand])
-        inputArray.remove(at: rand)
-    }
-    
-    return shuffledArray
 }
 
 func bogoSort(sortArray: inout [Int]) -> [Int] {
     while(!isSorted(inputArray: sortArray)) {
-        sortArray = shuffle(inputArray: &sortArray)
+        sortArray.shuffle()
     }
-    
+
     return sortArray
 }
 


### PR DESCRIPTION
XCode 10 was recently released and came out with Swift 4.2. So here is an updated version of Bogo Sort in Swift. I was able to get rid of the shuffle function I wrote and use Swift's new built in Shuffle function.