### PR TITLE
Updating Monte Carlo in Swift 4.1 to Swift 4.2

### DIFF
--- a/contents/monte_carlo_integration/code/swift/monte_carlo.swift
+++ b/contents/monte_carlo_integration/code/swift/monte_carlo.swift
@@ -1,18 +1,4 @@
-//Double Extension from YannickSteph on StackOverflow: https://stackoverflow.com/questions/25050309/swift-random-float-between-0-and-1
-
-import Foundation
-
-public extension Double {
-    public static var random: Double {
-        return Double(arc4random()) / 0xFFFFFFFF // Returns a random double between 0.0 and 1.0, inclusive.
-    }
-    
-    public static func random(min: Double, max: Double) -> Double {
-        return Double.random * (max - min) + min
-    }
-}
-
-func isInCircle(x: Double, y: Double, radius: Double) -> Bool {
+func inCircle(x: Double, y: Double, radius: Double) -> Bool {
     return (x*x) + (y*y) < radius*radius
 }
 
@@ -21,16 +7,16 @@ func monteCarlo(n: Int) -> Double {
     var piCount = 0
     var randX: Double
     var randY: Double
-    
+
     for _ in 0...n {
-        randX = Double.random(min: 0, max: radius)
-        randY = Double.random(min: 0, max: radius)
-        
-        if(isInCircle(x: randX, y: randY, radius: radius)) {
+        randX = Double.random(in: 0..<radius)
+        randY = Double.random(in: 0..<radius)
+
+        if(inCircle(x: randX, y: randY, radius: radius)) {
             piCount += 1
         }
     }
-    
+
     let piEstimate = Double(4 * piCount)/(Double(n))
     return piEstimate
 }
@@ -41,6 +27,4 @@ func main() {
     print("Percent error is: \(100 * abs(piEstimate - Double.pi)/Double.pi)%")
 }
 
-
 main()
-

--- a/contents/monte_carlo_integration/monte_carlo_integration.md
+++ b/contents/monte_carlo_integration/monte_carlo_integration.md
@@ -60,7 +60,7 @@ each point is tested to see whether it's in the circle or not:
 {% sample lang="java" %}
 [import:13-15, lang:"java"](code/java/MonteCarlo.java)
 {% sample lang="swift" %}
-[import:15-17, lang:"swift"](code/swift/monte_carlo.swift)
+[import:1-3, lang:"swift"](code/swift/monte_carlo.swift)
 {% sample lang="py" %}
 [import:5-7, lang:"python"](code/python/monte_carlo.py)
 {% sample lang="cs" %}


### PR DESCRIPTION
XCode 10 was recently released and came out with Swift 4.2. So here is an updated version of Monte Carlo Integration in Swift. I was able to get rid of the extension to create random numbers and used Swift's new built in functionality to do this.