### PR TITLE
Prevent Travis from deploying the book, even when it fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ language: node_js
 node_js:
   - "4"
 
-# cache:
-#   directories:
-#     - node_modules
-
 install:
   - npm install gitbook-cli -g
   - gitbook install
@@ -17,9 +13,11 @@ before_script:
   - mkdir -p "${TRAVIS_BUILD_DIR}"/build
 
 script:
-  - gitbook build . "${TRAVIS_BUILD_DIR}"/build
   - env | sort
-  - |
+  - gitbook build . "${TRAVIS_BUILD_DIR}"/build
+
+after_success:
+    - |
     if [[ "${TRAVIS_BRANCH}" == master && "${TRAVIS_PULL_REQUEST}" == false ]]; then
         # Commits to master that are not pull requests, that is, only
         # actual addition of code to master, should deploy the book to


### PR DESCRIPTION
https://docs.travis-ci.com/user/customizing-the-build/#customizing-the-build-step

Placing the deployment in `after_success` works around the fact that all
commands under `script` run even when one or more of them return a non-zero
exit code.