### PR TITLE
Haskell: added DFS Stack to Tree Traversal

### DIFF
--- a/contents/tree_traversal/code/haskell/TreeTraversal.hs
+++ b/contents/tree_traversal/code/haskell/TreeTraversal.hs
@@ -1,6 +1,7 @@
-data Tree a = Node { node :: a
-                   , forest :: [Tree a]
-                   } deriving (Show)
+data Tree a = Node
+  { node :: a
+  , forest :: [Tree a]
+  } deriving (Show)
 
 dfs :: Tree a -> [a]
 dfs (Node x ts) = x : concatMap dfs ts
@@ -9,15 +10,22 @@ dfsPostOrder :: Tree a -> [a]
 dfsPostOrder (Node x ts) = concatMap dfsPostOrder ts ++ [x]
 
 dfsInOrder :: Tree a -> [a] -- For binary trees only
-dfsInOrder (Node x [])     = [x]
-dfsInOrder (Node x [l])    = dfsInOrder l ++ [x] -- Single branch assumed to be left
+dfsInOrder (Node x []) = [x]
+dfsInOrder (Node x [l]) = dfsInOrder l ++ [x] -- Single branch assumed to be left
 dfsInOrder (Node x [l, r]) = dfsInOrder l ++ [x] ++ dfsInOrder r
-dfsInOrder _               = error "Not a binary tree"
+dfsInOrder _ = error "Not a binary tree"
+
+dfsStack :: Tree a -> [a]
+dfsStack t = go [t]
+  where
+    go [] = []
+    go ((Node x ts):stack) = x : go (ts ++ stack)
 
 bfs :: Tree a -> [a]
 bfs (Node x ts) = x : go ts
-  where go [] = []
-        go ts = map node ts ++ go (concatMap forest ts)
+  where
+    go [] = []
+    go ts = map node ts ++ go (concatMap forest ts)
 
 toBin :: Tree a -> Tree a
 toBin (Node x ts) = Node x (map toBin $ take 2 ts)
@@ -26,18 +34,19 @@ main = do
   print $ dfs testTree
   print $ dfsPostOrder testTree
   print $ dfsInOrder $ toBin testTree
+  print $ dfsStack testTree
   print $ bfs testTree
 
 testTree :: Tree Int
-testTree = Node 1 [ Node 2 [ Node 3 []
-                           , Node 4 [ Node 5 []]
-                           ]
-                  , Node 6 [ Node 7 []
-                           , Node 8 [ Node 9 [ Node 10 [ Node 11 []]
-                                             , Node 12 []
-                                             ]
-                                    ]
-                           , Node 13 [ Node 14 []]
-                           ]
-                   , Node 15 []
-                   ]
+testTree =
+  Node
+    1
+    [ Node 2 [Node 3 [], Node 4 [Node 5 []]]
+    , Node
+        6
+        [ Node 7 []
+        , Node 8 [Node 9 [Node 10 [Node 11 []], Node 12 []]]
+        , Node 13 [Node 14 []]
+        ]
+    , Node 15 []
+    ]

--- a/contents/tree_traversal/tree_traversal.md
+++ b/contents/tree_traversal/tree_traversal.md
@@ -25,7 +25,7 @@ This has not been implemented in your chosen language, so here is the Julia code
 {% sample lang="rs"%}
 [import:4-7, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-[import:1-3, lang:"haskell"](code/haskell/TreeTraversal.hs)
+[import:1-4, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
 [import:1-9, lang:"swift"](code/swift/tree.swift)
 {% sample lang="php"%}
@@ -59,7 +59,7 @@ Because of this, the most straightforward way to traverse the tree might be recu
 {% sample lang="rs"%}
 [import:9-15 lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-[import:5-6, lang:"haskell"](code/haskell/TreeTraversal.hs)
+[import:6-7, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
 [import:24-30, lang:"swift"](code/swift/tree.swift)
 {% sample lang="php"%}
@@ -101,7 +101,7 @@ Now, in this case the first element searched through is still the root of the tr
 {% sample lang="rs"%}
 [import:17-23, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-[import:8-9, lang:"haskell"](code/haskell/TreeTraversal.hs)
+[import:9-10, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
 [import:32-38, lang:"swift"](code/swift/tree.swift)
 {% sample lang="php"%}
@@ -138,7 +138,7 @@ In this case, the first node visited is at the bottom of the tree and moves up t
 {% sample lang="rs"%}
 [import:25-38, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-[import:11-15, lang:"haskell"](code/haskell/TreeTraversal.hs)
+[import:12-16, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
 [import:40-53, lang:"swift"](code/swift/tree.swift)
 {% sample lang="php"%}

--- a/contents/tree_traversal/tree_traversal.md
+++ b/contents/tree_traversal/tree_traversal.md
@@ -185,8 +185,7 @@ In code, it looks like this:
 {% sample lang="rs"%}
 [import:40-47, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-This has not been implemented in your chosen language, so here is the Julia code
-[import:45-56, lang:"julia"](code/julia/Tree.jl)
+[import:18-22, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
 [import:55-67, lang:"swift"](code/swift/tree.swift)
 {% sample lang="php"%}
@@ -225,7 +224,7 @@ And this is exactly what Breadth-First Search (BFS) does! On top of that, it can
 {% sample lang="rs"%}
 [import:49-57, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
-[import:17-20, lang:"haskell"](code/haskell/TreeTraversal.hs)
+[import:24-28, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
 [import:69-81, lang:"swift"](code/swift/tree.swift)
 {% sample lang="php"%}


### PR DESCRIPTION
Added DFS Stack.
I also ran hindent which reformatted the file, so I had to change all import lines.

For the record, it's not _really_ using stacks, just as BFS is not _really_ using queues and the other DFS  implementations are definitely better. I'm just adding it for completeness.