### PR TITLE
Fixed line numbers for C lang for the split operator markdown

### DIFF
--- a/contents/split-operator_method/split-operator_method.md
+++ b/contents/split-operator_method/split-operator_method.md
@@ -100,8 +100,8 @@ Regardless, we first need to set all the initial parameters, including the initi
 {% sample lang="jl" %}
 [import:11-34, lang:"julia"](code/julia/split_op.jl)
 {% sample lang="c" %}
-[import:10-20, lang:"c_cpp"](code/c/split_op.c)
-[import:51-72, lang:"c_cpp"](code/c/split_op.c)
+[import:11-21, lang:"c_cpp"](code/c/split_op.c)
+[import:52-73, lang:"c_cpp"](code/c/split_op.c)
 {% sample lang="py" %}
 [import:11-30, lang:"python"](code/python/split_op.py)
 {% sample lang="hs" %}
@@ -119,8 +119,8 @@ Afterwards, we turn them into operators:
 {% sample lang="jl" %}
 [import:36-62, lang:"julia"](code/julia/split_op.jl)
 {% sample lang="c" %}
-[import:22-28, lang:"c_cpp"](code/c/split_op.c)
-[import:74-95, lang:"c_cpp"](code/c/split_op.c)
+[import:23-29, lang:"c_cpp"](code/c/split_op.c)
+[import:75-96, lang:"c_cpp"](code/c/split_op.c)
 {% sample lang="py" %}
 [import:33-54, lang:"python"](code/python/split_op.py)
 {% sample lang="hs" %}
@@ -139,7 +139,7 @@ The final step is to do the iteration, itself.
 {% sample lang="jl" %}
 [import:65-112, lang:"julia"](code/julia/split_op.jl)
 {% sample lang="c" %}
-[import:97-145, lang:"c_cpp"](code/c/split_op.c)
+[import:98-148, lang:"c_cpp"](code/c/split_op.c)
 {% sample lang="py" %}
 [import:57-95, lang:"python"](code/python/split_op.py)
 {% sample lang="hs" %}


### PR DESCRIPTION
This pull request is one of the two new pull requests requested in #409 and is made to fix the line numbers in the C lang implementation in the split operator method.