### PR TITLE
Monte carlo C fix

### DIFF
--- a/contents/monte_carlo_integration/code/c/monte_carlo.c
+++ b/contents/monte_carlo_integration/code/c/monte_carlo.c
@@ -8,7 +8,7 @@ bool in_circle(double x, double y, double radius) {
     return x * x + y * y < radius * radius;
 }
 
-void monte_carlo(int samples) {
+double monte_carlo(int samples) {
     double radius = 1.0;
     int count = 0;
 
@@ -21,10 +21,7 @@ void monte_carlo(int samples) {
         }
     }
 
-    double estimate = 4.0 * count / (samples * radius * radius);
-
-    printf("The estimate of pi is %f\n", estimate);
-    printf("Percentage error: %0.2f%\n", 100 * fabs(M_PI - estimate) / M_PI);
+    return 4.0 * count / samples;
 }
 
 int main() {

--- a/contents/monte_carlo_integration/code/c/monte_carlo.c
+++ b/contents/monte_carlo_integration/code/c/monte_carlo.c
@@ -13,8 +13,8 @@ void monte_carlo(int samples) {
     int count = 0;
 
     for (int i = 0; i < samples; ++i) {
-        double x = (double)rand() * 2.0 / RAND_MAX - 1.0;
-        double y = (double)rand() * 2.0 / RAND_MAX - 1.0;
+        double x = (double)rand() * radius / RAND_MAX;
+        double y = (double)rand() * radius / RAND_MAX;
 
         if (in_circle(x, y, radius)) {
             count += 1;
@@ -30,7 +30,10 @@ void monte_carlo(int samples) {
 int main() {
     srand(time(NULL));
 
-    monte_carlo(1000000);
-
+    double estimate = monte_carlo(1000000);
+	
+    printf("The estimate of pi is %f\n", estimate);
+    printf("Percentage error: %0.2f%\n", 100 * fabs(M_PI - estimate) / M_PI);
+	
     return 0;
 }


### PR DESCRIPTION
MonteCarlo in C was not implemented as described by the book. In the book we are told to use only the first quadrant to calculate pi. The C code produces a random range from -1 to +1. While the method stills works I think we should keep code to follow the algorithm as described by the book.

I also removed the incorrect formula where radius != 0.0 and replaced it with code to product random variables from 0 to radius.

Another smaller change was changing the return type to double. The function should only calculate pi and return it, there's no need for it to also print the estimation and how close it was, that can be left up to the main function.