### PR TITLE
Implement bubble sort in Hy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,6 +55,11 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+# Hy
+[*.hy]
+indent_style = space
+indent_size = 2
+
 # Java
 [*.java]
 indent_style = space

--- a/book.json
+++ b/book.json
@@ -65,6 +65,10 @@
           "name": "Haskell"
         },
         {
+          "lang": "hy",
+          "name": "Hy"
+        },
+        {
           "lang": "rs",
           "name": "Rust"
         },

--- a/contents/bubble_sort/bubble_sort.md
+++ b/contents/bubble_sort/bubble_sort.md
@@ -14,6 +14,8 @@ This means that we need to go through the vector $$\mathcal{O}(n^2)$$ times with
 [import:9-27, lang:"csharp"](code/csharp/BubbleSort.cs)
 {% sample lang="c" %}
 [import:10-20, lang:"c_cpp"](code/c/bubble_sort.c)
+{% sample lang="hy" %}
+[import:9-23, lang:"hy"](code/hy/bubble_sort.hy)
 {% sample lang="java" %}
 [import:2-12, lang:"java"](code/java/bubble.java)
 {% sample lang="kotlin" %}
@@ -81,6 +83,8 @@ Trust me, there are plenty of more complicated algorithms that do precisely the 
 [import, lang:"csharp"](code/csharp/Program.cs)
 {% sample lang="c" %}
 [import, lang:"c_cpp"](code/c/bubble_sort.c)
+{% sample lang="hy" %}
+[import, lang:"hy"](code/hy/bubble_sort.hy)
 {% sample lang="java" %}
 [import, lang:"java"](code/java/bubble.java)
 {% sample lang="kotlin" %}

--- a/contents/bubble_sort/code/hy/bubble_sort.hy
+++ b/contents/bubble_sort/code/hy/bubble_sort.hy
@@ -1,0 +1,25 @@
+(require [hy.contrib.walk [let]])
+
+(defn cons [a b]
+  (do
+    (setv c (.copy (list b)))
+    (.insert c 0 a)
+    c))
+
+(defn bubble-up [l]
+  (if (< (len (list l)) 2)
+      l
+      (if (> (first l) (second l))
+          (cons (second l)
+                (bubble-up (cons (first l) (rest (rest l)))))
+          (cons (first l)
+                (bubble-up (list (rest l)))))))
+
+(defn bubble-sort [l]
+  (if (< (len (list l)) 2)
+      l
+      (let [new-list (bubble-up l)]
+           (+ (bubble-sort (list (butlast new-list)))
+              [(last new-list)]))))
+
+(print (bubble-sort [1 45 756 4569 56 3 8 5 -10 -4]))


### PR DESCRIPTION
Since someone took the first Kotlin implementation from me, Hy is a Lisp that transpiles to Python: http://docs.hylang.org/en/stable/index.html