### PR TITLE
Fixed a typo in the Julia implementation for Stable Marriage

### DIFF
--- a/contents/stable_marriage_problem/code/julia/stable_marriage.jl
+++ b/contents/stable_marriage_problem/code/julia/stable_marriage.jl
@@ -21,7 +21,7 @@ prefers(prefs, person, first, second) =
 
 isfree(person, pairs) = !haskey(pairs, person)
 
-function galeshapely(men::Preferences, women::Preferences)
+function galeshapley(men::Preferences, women::Preferences)
     mentowomen = Dict{String,String}()
     womentomen = Dict{String,String}()
     while true
@@ -62,7 +62,7 @@ end
 
 function main()
     men, women = genpreferences(mnames, wnames)
-    mentowomen, womentomen = galeshapely(men, women)
+    mentowomen, womentomen = galeshapley(men, women)
     println(mentowomen)
     println(isstable(men, women, mentowomen, womentomen) ? "Stable" : "Unstable")
 end


### PR DESCRIPTION
Tiny change. The function was named `galeshapely` instead of `galeshapley`.