### PR TITLE
Python verlet line numbers

### DIFF
--- a/contents/stable_marriage_problem/code/julia/stable_marriage.jl
+++ b/contents/stable_marriage_problem/code/julia/stable_marriage.jl
@@ -21,7 +21,7 @@ prefers(prefs, person, first, second) =
 
 isfree(person, pairs) = !haskey(pairs, person)
 
-function galeshapely(men::Preferences, women::Preferences)
+function galeshapley(men::Preferences, women::Preferences)
     mentowomen = Dict{String,String}()
     womentomen = Dict{String,String}()
     while true
@@ -62,7 +62,7 @@ end
 
 function main()
     men, women = genpreferences(mnames, wnames)
-    mentowomen, womentomen = galeshapely(men, women)
+    mentowomen, womentomen = galeshapley(men, women)
     println(mentowomen)
     println(isstable(men, women, mentowomen, womentomen) ? "Stable" : "Unstable")
 end

--- a/contents/verlet_integration/verlet_integration.md
+++ b/contents/verlet_integration/verlet_integration.md
@@ -39,7 +39,7 @@ Here is what it looks like in code:
 {% sample lang="java" %}
 [import:13-28, lang:"java"](code/java/Verlet.java)
 {% sample lang="py" %}
-[import:1-9, lang:"python"](code/python/verlet.py)
+[import:1-10, lang:"python"](code/python/verlet.py)
 {% sample lang="hs" %}
 [import:14-21, lang:"haskell"](code/haskell/verlet.hs)
 {% sample lang="scratch" %}
@@ -85,7 +85,7 @@ However, the error for this is $$\mathcal{O}(\Delta t)$$, which is quite poor, b
 {% sample lang="java" %}
 [import:30-49, lang:"java"](code/java/Verlet.java)
 {% sample lang="py" %}
-[import:11-21, lang:"python"](code/python/verlet.py)
+[import:12-23, lang:"python"](code/python/verlet.py)
 {% sample lang="hs" %}
 [import:23-28, lang:"haskell"](code/haskell/verlet.hs)
 {% sample lang="scratch" %}
@@ -145,7 +145,7 @@ Here is the velocity Verlet method in code:
 {% sample lang="java" %}
 [import:51-65, lang:"java"](code/java/Verlet.java)
 {% sample lang="py" %}
-[import:23-32, lang:"python"](code/python/verlet.py)
+[import:25-34, lang:"python"](code/python/verlet.py)
 {% sample lang="hs" %}
 [import:30-35, lang:"haskell"](code/haskell/verlet.hs)
 {% sample lang="scratch" %}


### PR DESCRIPTION
The line numbers of the Python code imports for Verlet integration were all wrong. The functions were cut off.