### PR TITLE
Clean up Java implementation of Thomas Algorithm

### DIFF
--- a/contents/thomas_algorithm/code/java/Thomas.java
+++ b/contents/thomas_algorithm/code/java/Thomas.java
@@ -1,20 +1,23 @@
 public class Thomas {
-    private static void thomasAlgorithm(double a[], double b[], double c[], double x[], int size) {
-
+    private static double[] thomasAlgorithm(double a[], double b[], double c[], double x[]) {
+        int size = a.length;
         double y[] = new double[size];
+        double solution[] = new double[size];
 
         y[0] = c[0] / b[0];
-        x[0] = x[0] / b[0];
+        solution[0] = x[0] / b[0];
 
         for (int i = 1; i < size; ++i) {
             double scale = 1.0 / (b[i] - a[i] * y[i - 1]);
             y[i] = c[i] * scale;
-            x[i] = (x[i] - a[i] * x[i - 1]) * scale;
+            solution[i] = (x[i] - a[i] * solution[i - 1]) * scale;
         }
 
         for (int i = size - 2; i >= 0; --i) {
-            x[i] -= y[i] * x[i + 1];
+            solution[i] -= y[i] * solution[i + 1];
         }
+
+        return solution;
     }
 
     public static void main(String[] args) {
@@ -29,9 +32,9 @@ public class Thomas {
         System.out.println("[0.0  3.0  6.0][z] = [3.0]\n");
         System.out.println("has the solution:\n");
 
-        thomasAlgorithm(a, b, c, x, 3);
+        double solution[] = thomasAlgorithm(a, b, c, x);
 
         for (int i = 0; i < 3; ++i)
-            System.out.println("[" + x[i] + "]\n");
+            System.out.println("[" + solution[i] + "]\n");
     }
 }

--- a/contents/thomas_algorithm/code/java/Thomas.java
+++ b/contents/thomas_algorithm/code/java/Thomas.java
@@ -25,16 +25,16 @@ public class Thomas {
         double b[] = {1.0, 3.0, 6.0};
         double c[] = {4.0, 5.0, 0.0};
         double x[] = {7.0, 5.0, 3.0};
-
-        System.out.println("The system,\n");
-        System.out.println("[1.0  4.0  0.0][x] = [7.0]\n");
-        System.out.println("[2.0  3.0  5.0][y] = [5.0]\n");
-        System.out.println("[0.0  3.0  6.0][z] = [3.0]\n");
-        System.out.println("has the solution:\n");
-
         double solution[] = thomasAlgorithm(a, b, c, x);
 
-        for (int i = 0; i < 3; ++i)
-            System.out.println("[" + solution[i] + "]\n");
+        System.out.format("The system,\n");
+        System.out.format("[%.1f, %.1f, %.1f][x] = [%.1f]\n", b[0], c[0], 0f, x[0]);
+        System.out.format("[%.1f, %.1f, %.1f][y] = [%.1f]\n", a[1], b[1], c[1], x[1]);
+        System.out.format("[%.1f, %.1f, %.1f][z] = [%.1f]\n", 0f, a[2], b[2], x[2]);
+        System.out.format("has the solution:\n");
+
+        for (int i = 0; i < 3; ++i) {
+            System.out.format("[% .5f]\n", solution[i]);
+        }
     }
 }

--- a/contents/thomas_algorithm/code/java/Thomas.java
+++ b/contents/thomas_algorithm/code/java/Thomas.java
@@ -1,8 +1,8 @@
 public class Thomas {
-    private static double[] thomasAlgorithm(double a[], double b[], double c[], double x[]) {
+    private static double[] thomasAlgorithm(double[] a, double[] b, double[] c, double[] x) {
         int size = a.length;
-        double y[] = new double[size]; // This is needed so that we don't have to modify c
-        double solution[] = new double[size];
+        double[] y = new double[size]; // This is needed so that we don't have to modify c
+        double[] solution = new double[size];
 
         // Set initial elements
         y[0] = c[0] / b[0];
@@ -24,11 +24,11 @@ public class Thomas {
     }
 
     public static void main(String[] args) {
-        double a[] = {0.0, 2.0, 3.0};
-        double b[] = {1.0, 3.0, 6.0};
-        double c[] = {4.0, 5.0, 0.0};
-        double x[] = {7.0, 5.0, 3.0};
-        double solution[] = thomasAlgorithm(a, b, c, x);
+        double[] a = {0.0, 2.0, 3.0};
+        double[] b = {1.0, 3.0, 6.0};
+        double[] c = {4.0, 5.0, 0.0};
+        double[] x = {7.0, 5.0, 3.0};
+        double[] solution = thomasAlgorithm(a, b, c, x);
 
         System.out.format("The system,\n");
         System.out.format("[%.1f, %.1f, %.1f][x] = [%.1f]\n", b[0], c[0], 0f, x[0]);

--- a/contents/thomas_algorithm/code/java/Thomas.java
+++ b/contents/thomas_algorithm/code/java/Thomas.java
@@ -36,7 +36,7 @@ public class Thomas {
         System.out.format("[%.1f, %.1f, %.1f][z] = [%.1f]\n", 0f, a[2], b[2], x[2]);
         System.out.format("has the solution:\n");
 
-        for (int i = 0; i < 3; ++i) {
+        for (int i = 0; i < solution.length; i++) {
             System.out.format("[% .5f]\n", solution[i]);
         }
     }

--- a/contents/thomas_algorithm/code/java/Thomas.java
+++ b/contents/thomas_algorithm/code/java/Thomas.java
@@ -1,4 +1,4 @@
-public class thomas {
+public class Thomas {
     private static void thomasAlgorithm(double a[], double b[], double c[], double x[], int size) {
 
         double y[] = new double[size];

--- a/contents/thomas_algorithm/code/java/Thomas.java
+++ b/contents/thomas_algorithm/code/java/Thomas.java
@@ -1,18 +1,21 @@
 public class Thomas {
     private static double[] thomasAlgorithm(double a[], double b[], double c[], double x[]) {
         int size = a.length;
-        double y[] = new double[size];
+        double y[] = new double[size]; // This is needed so that we don't have to modify c
         double solution[] = new double[size];
 
+        // Set initial elements
         y[0] = c[0] / b[0];
         solution[0] = x[0] / b[0];
 
         for (int i = 1; i < size; ++i) {
+            // Scale factor is for c and x
             double scale = 1.0 / (b[i] - a[i] * y[i - 1]);
             y[i] = c[i] * scale;
             solution[i] = (x[i] - a[i] * solution[i - 1]) * scale;
         }
 
+        // Back-substitution
         for (int i = size - 2; i >= 0; --i) {
             solution[i] -= y[i] * solution[i + 1];
         }

--- a/contents/thomas_algorithm/thomas_algorithm.md
+++ b/contents/thomas_algorithm/thomas_algorithm.md
@@ -108,7 +108,7 @@ You will find this algorithm implemented [in this project](https://scratch.mit.e
   <img  class="center" src="code/scratch/thomas.svg" width="1000" />
 </p>
 {% sample lang="java" %}
-[import, lang:"java"](code/java/thomas.java)
+[import, lang:"java"](code/java/Thomas.java)
 {% sample lang="hs" %}
 [import, lang:"haskell"](code/haskell/thomas.hs)
 {% sample lang="go" %}


### PR DESCRIPTION
When merged, this PR fixes a few issues with the Java implementation of the Thomas algorithm and also changes it so that it works similarly to the new Julia implementation (#495).

* The class and file name were `thomas`, but classes in Java should be PascalCase, so I renamed them to `Thomas`.

* The `thomasAlgorithm` method had a `int size` parameter, which is not needed in Java. I assume that the code was directly ported from the C implementation and that was not taken out.

* I had a short talk with @leios on stream today. I mentioned how almost none of the implementations return the result. Instead, they all modify the input vector, which they get passed by reference. The new version of this does not modify any of the input vectors and returns the output vector.

* The output was quite messy, also as a result of the fact that the code was directly ported over from C.

* All the array declarations were formatted as `double x[]` instead of `double[] x`. The latter is, as far as I know, the preferred way in Java. This is probably also an artifact of the port from C.

* Lastly, I made the output dynamic. The output is hard-coded in almost all implementations and I think we should change that. It's not that difficult.

Note: I don't know why GitHub reports thomas.py as deleted and Thomas.py as new. I used `git mv` to rename the file.