### PR TITLE
Added crystal to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,11 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+# Crystal
+[*.cr]
+indent_style = space
+indent_size = 2
+
 # C#
 [*.cs]
 indent_style = space


### PR DESCRIPTION
Crystal has its own formatter anyway (`crystal tool format`), but this is still nice to have.