### PR TITLE
Added package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ anaconda-mode/
 ## https://docs.npmjs.com/misc/faq#should-i-check-my-node_modules-folder-into-git
 node_modules
 
+# npm package lock for local installs
+package-lock.json
+
 # Book build output
 _book
 


### PR DESCRIPTION
I installed gitbook locally, so npm generated the package-lock.json file. As it is not part of the repo, it should be ignored.