### PR TITLE
Added exclamation marks to mutating julia functions

### DIFF
--- a/contents/bogo_sort/code/julia/bogo.jl
+++ b/contents/bogo_sort/code/julia/bogo.jl
@@ -9,15 +9,15 @@ function is_sorted(a::Vector{Float64})
     return true
 end
 
-function bogo_sort(a::Vector{Float64})
+function bogo_sort!(a::Vector{Float64})
     while(!is_sorted(a))
         shuffle!(a)
     end
 end
 
 function main()
-    a = [1, 3, 2, 4]
-    bogo_sort(a)
+    a = [1.0, 3.0, 2.0, 4.0]
+    bogo_sort!(a)
     println(a)
 end
 

--- a/contents/bubble_sort/code/julia/bubble.jl
+++ b/contents/bubble_sort/code/julia/bubble.jl
@@ -1,4 +1,4 @@
-function bubble_sort(a::Vector{Float64})
+function bubble_sort!(a::Vector{Float64})
     n = length(a)
     for i = 1:n
         for j = 1:n-1
@@ -12,7 +12,7 @@ end
 
 function main()
     a = [1., 3, 2, 4, 5, 10, 50, 7, 1.5, 0.3]
-    bubble_sort(a)
+    bubble_sort!(a)
     println(a)
 end
 

--- a/contents/gaussian_elimination/code/julia/gaussian_elimination.jl
+++ b/contents/gaussian_elimination/code/julia/gaussian_elimination.jl
@@ -1,4 +1,4 @@
-function gaussian_elimination(A::Array{Float64,2})
+function gaussian_elimination!(A::Array{Float64,2})
 
     rows = size(A,1)
     cols = size(A,2)
@@ -64,7 +64,7 @@ function back_substitution(A::Array{Float64,2})
 end
 
 
-function gauss_jordan_elimination(A::Array{Float64,2})
+function gauss_jordan_elimination!(A::Array{Float64,2})
 
     rows = size(A,1)
     cols = size(A,2)
@@ -97,10 +97,10 @@ function main()
          1 2 3 4;
          3 -4 0 10]
 
-    gaussian_elimination(A)
+    gaussian_elimination!(A)
     println(A)
 
-    gauss_jordan_elimination(A)
+    gauss_jordan_elimination!(A)
     println(A)
 
     soln = back_substitution(A)

--- a/contents/graham_scan/code/julia/graham.jl
+++ b/contents/graham_scan/code/julia/graham.jl
@@ -7,7 +7,7 @@ function ccw(a::Point, b::Point, c::Point)
     return ((b.x - a.x)*(c.y - a.y) - (b.y - a.y)*(c.x - a.x))
 end
 
-function graham_scan(points::Vector{Point})
+function graham_scan!(points::Vector{Point})
     N = length(points)
 
     # Place the lowest point at the start of the array
@@ -51,7 +51,7 @@ function main()
         Point(-1,-1), Point(-10,11), Point(-6,15), Point(-6,-8), Point(15,-9),
         Point(7,-7), Point(-2,-9), Point(6,-5), Point(0,14), Point(2,8)
     ]
-    hull = graham_scan(points)
+    hull = graham_scan!(points)
     println(hull)
 end
 

--- a/contents/huffman_encoding/code/julia/huffman.jl
+++ b/contents/huffman_encoding/code/julia/huffman.jl
@@ -16,15 +16,15 @@ const Node = Union{Leaf, Branch}
 isbranch(branch::Branch) = true
 isbranch(other::T) where {T} = false
 
-function codebook_recurse(leaf::Leaf, code::String,
+function codebook_recurse!(leaf::Leaf, code::String,
                           dict::Dict{Char,String})
     dict[leaf.key] = code
 end
 
-function codebook_recurse(branch::Branch, code::String,
+function codebook_recurse!(branch::Branch, code::String,
                           dict::Dict{Char,String})
-    codebook_recurse(branch.left, string(code, "1"), dict)
-    codebook_recurse(branch.right, string(code, "0"), dict)
+    codebook_recurse!(branch.left, string(code, "1"), dict)
+    codebook_recurse!(branch.right, string(code, "0"), dict)
 end
 
 # This will depth-first search through the tree
@@ -33,7 +33,7 @@ end
 # This outputs encoding Dict to be used for encoding
 function create_codebook(n::Node)
     codebook = Dict{Char,String}()
-    codebook_recurse(n, "", codebook)
+    codebook_recurse!(n, "", codebook)
     return codebook
 end
 

--- a/contents/split-operator_method/code/julia/split_op.jl
+++ b/contents/split-operator_method/code/julia/split_op.jl
@@ -62,7 +62,7 @@ function init(par::Param, voffset::Float64, wfcoffset::Float64)
 end
 
 # Function for the split-operator loop
-function split_op(par::Param, opr::Operators)
+function split_op!(par::Param, opr::Operators)
 
     for i = 1:par.timesteps
         # Half-step in real space
@@ -126,7 +126,7 @@ function calculate_energy(par, opr)
     energy_final = 0
     for i = 1:length(energy_k)
         energy_final += real(energy_k[i] + energy_r[i])
-    end 
+    end
 
     return energy_final*par.dx
 end
@@ -137,7 +137,7 @@ function main()
 
     # Starting wavefunction slightly offset so we can see it change
     opr = init(par, 0.0, -1.00)
-    split_op(par, opr)
+    split_op!(par, opr)
 
     energy = calculate_energy(par, opr)
     println("Energy is: ", energy)


### PR DESCRIPTION
By convention, Julia functions that mutate one of their parameters need to have an exclamation mark at the end of their name; this fixes all instances of that that I could find.