### PR TITLE
fixing monte_carlo markdown file name error for lisp / scala

### DIFF
--- a/contents/monte_carlo_integration/monte_carlo_integration.md
+++ b/contents/monte_carlo_integration/monte_carlo_integration.md
@@ -84,7 +84,7 @@ each point is tested to see whether it's in the circle or not:
 {% sample lang="scala" %}
 [import:3-3, lang:"scala"](code/scala/monte_carlo.scala)
 {% sample lang="lisp" %}
-[import:3-5, lang:"lisp"](code/scala/monte-carlo.lisp)
+[import:3-5, lang:"lisp"](code/lisp/monte-carlo.lisp)
 {% sample lang="asm-x64" %}
 [import:21-32, lang:"asm-x64"](code/asm-x64/monte_carlo.s)
 {% endmethod %}
@@ -170,11 +170,10 @@ Feel free to submit your version via pull request, and thanks for reading!
 {% sample lang="scala" %}
 [import, lang:"scala"](code/scala/monte_carlo.scala)
 {% sample lang="lisp" %}
-[import, lang:"lisp"](code/scala/monte-carlo.lisp)
+[import, lang:"lisp"](code/lisp/monte-carlo.lisp)
 {% sample lang="asm-x64" %}
 [import, lang:"asm-x64"](code/asm-x64/monte_carlo.s)
 {% endmethod %}
-
 
 
 <script>


### PR DESCRIPTION
Small problem I didn't notice when merging #524 (I think that was the PR).