### PR TITLE
modifying C++ energy calculation to match split-op code.

### DIFF
--- a/contents/quantum_systems/quantum_systems.md
+++ b/contents/quantum_systems/quantum_systems.md
@@ -232,7 +232,7 @@ This ultimately looks like this:
 {% sample lang="c" %}
 [import:29-, lang:"c_cpp"](code/c/energy.c)
 {% sample lang="cpp" %}
-[import:26-57, lang:"c_cpp"](code/c++/energy.cpp)
+[import:29-62, lang:"c_cpp"](code/c++/energy.cpp)
 {% sample lang="py" %}
 [import:4-17, lang:"python"](code/python/energy.py)
 {% endmethod %}


### PR DESCRIPTION
I screwed up with #476 . At first glance, it looked fine, but there were obvious updates necessary. This should match #420.

@rajdakin Sorry for prematurely merging.