### PR TITLE
Format Rust code using rustfmt

### DIFF
--- a/contents/bogo_sort/code/rust/bogosort.rs
+++ b/contents/bogo_sort/code/rust/bogosort.rs
@@ -4,16 +4,16 @@ extern crate rand;
 
 use rand::{thread_rng, Rng};
 
-fn is_sorted(arr : &[i32]) -> bool {
+fn is_sorted(arr: &[i32]) -> bool {
     for i in 1..arr.len() {
-        if arr[i-1] > arr[i] {
+        if arr[i - 1] > arr[i] {
             return false;
         }
     }
     true
 }
 
-fn bogo_sort(arr : &mut [i32]) {
+fn bogo_sort(arr: &mut [i32]) {
     while !is_sorted(arr) {
         thread_rng().shuffle(arr);
     }

--- a/contents/bubble_sort/code/rust/bubble_sort.rs
+++ b/contents/bubble_sort/code/rust/bubble_sort.rs
@@ -1,7 +1,7 @@
 extern crate rand; // External crate that provides random number generation tools
 
-use rand::{thread_rng, Rng}; // Used for random number generation
 use rand::distributions::Uniform; // Used for a uniform distribution
+use rand::{thread_rng, Rng}; // Used for random number generation
 
 fn bubble_sort(a: &mut [u32]) {
     let n = a.len();

--- a/contents/euclidean_algorithm/code/rust/euclidean_example.rs
+++ b/contents/euclidean_algorithm/code/rust/euclidean_example.rs
@@ -32,4 +32,3 @@ fn main() {
     println!("{}", chk1);
     println!("{}", chk2);
 }
-

--- a/contents/monte_carlo_integration/code/rust/monte_carlo.rs
+++ b/contents/monte_carlo_integration/code/rust/monte_carlo.rs
@@ -26,5 +26,8 @@ fn monte_carlo(n: i64) -> f64 {
 fn main() {
     let pi_estimate = monte_carlo(10000000);
 
-    println!("Percent error is {:.3}%", (100.0 * (pi_estimate - PI).abs() / PI));
+    println!(
+        "Percent error is {:.3}%",
+        (100.0 * (pi_estimate - PI).abs() / PI)
+    );
 }

--- a/contents/tree_traversal/code/rust/tree.rs
+++ b/contents/tree_traversal/code/rust/tree.rs
@@ -23,7 +23,7 @@ fn dfs_recursive_postorder(n: &Node) {
 }
 
 fn dfs_recursive_inorder_btree(n: &Node) {
-    if n.children.len() == 2{
+    if n.children.len() == 2 {
         dfs_recursive_inorder_btree(&n.children[1]);
         println!("{}", n.value);
         dfs_recursive_inorder_btree(&n.children[0]);
@@ -46,7 +46,7 @@ fn dfs_stack(n: &Node) {
     }
 }
 
-fn bfs_queue(n: &Node){
+fn bfs_queue(n: &Node) {
     let mut queue = VecDeque::new();
     queue.push_back(n);
 
@@ -58,14 +58,20 @@ fn bfs_queue(n: &Node){
 
 fn create_tree(num_row: u64, num_child: u64) -> Node {
     if num_row == 0 {
-        return Node { children: vec![], value: 0 };
+        return Node {
+            children: vec![],
+            value: 0,
+        };
     }
 
     let children = (0..num_child)
         .map(|_| create_tree(num_row - 1, num_child))
         .collect();
 
-    Node { children, value: num_row }
+    Node {
+        children,
+        value: num_row,
+    }
 }
 
 fn main() {

--- a/contents/verlet_integration/code/rust/verlet.rs
+++ b/contents/verlet_integration/code/rust/verlet.rs
@@ -50,6 +50,12 @@ fn main() {
     let (time_vv, vel_vv) = velocity_verlet(5.0, -10.0, 0.01);
 
     println!("Time for original Verlet integration: {}", time_v);
-    println!("Time and velocity for Stormer Verlet integration: {}, {}", time_sv, vel_sv);
-    println!("Time and velocity for velocity Verlet integration: {}, {}", time_vv, vel_vv);
+    println!(
+        "Time and velocity for Stormer Verlet integration: {}, {}",
+        time_sv, vel_sv
+    );
+    println!(
+        "Time and velocity for velocity Verlet integration: {}, {}",
+        time_vv, vel_vv
+    );
 }


### PR DESCRIPTION
Simply formats the Rust code using the community standard formatting ([`rustfmt`](https://github.com/rust-lang/rustfmt)).