### PR TITLE
Use pattern matching in tree traversal (Rust)

### DIFF
--- a/contents/tree_traversal/code/rust/tree.rs
+++ b/contents/tree_traversal/code/rust/tree.rs
@@ -23,17 +23,18 @@ fn dfs_recursive_postorder(n: &Node) {
 }
 
 fn dfs_recursive_inorder_btree(n: &Node) {
-    if n.children.len() == 2{
-        dfs_recursive_inorder_btree(&n.children[1]);
-        println!("{}", n.value);
-        dfs_recursive_inorder_btree(&n.children[0]);
-    } else if n.children.len() == 1 {
-        dfs_recursive_inorder_btree(&n.children[0]);
-        println!("{}", n.value);
-    } else if n.children.len() == 0 {
-        println!("{}", n.value);
-    } else {
-        println!("This is not a binary tree.");
+    match &n.children[..] {
+        [left, right] => {
+            dfs_recursive_inorder_btree(left);
+            println!("{}", n.value);
+            dfs_recursive_inorder_btree(right);
+        }
+        [left] => {
+            dfs_recursive_inorder_btree(left);
+            println!("{}", n.value);
+        }
+        [] => println!("{}", n.value),
+        _ => println!("This is not a binary tree."),
     }
 }
 
@@ -70,14 +71,19 @@ fn create_tree(num_row: u64, num_child: u64) -> Node {
 
 fn main() {
     let root = create_tree(2, 3);
+
     println!("Recursive DFS:");
     dfs_recursive(&root);
+
     println!("Stack DFS:");
     dfs_stack(&root);
+
     println!("Queue BFS:");
     bfs_queue(&root);
+
     println!("Recursive post-order DFS:");
     dfs_recursive_postorder(&root);
+
     println!("Recursive in-order DFS BTree:");
     let root_binary = create_tree(3, 2);
     dfs_recursive_inorder_btree(&root_binary);

--- a/contents/tree_traversal/tree_traversal.md
+++ b/contents/tree_traversal/tree_traversal.md
@@ -111,7 +111,7 @@ Now, in this case the first element searched through is still the root of the tr
   <img  class="center" src="code/scratch/dfs-post.svg" width="300" />
 </p>
 {% sample lang="rs"%}
-[import:17-23, lang:"rust"](code/rust/tree.rs)
+[import:17-24, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
 [import:9-10, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
@@ -154,7 +154,7 @@ In this case, the first node visited is at the bottom of the tree and moves up t
   <img  class="center" src="code/scratch/dfs-in.svg" width="300" />
 </p>
 {% sample lang="rs"%}
-[import:25-38, lang:"rust"](code/rust/tree.rs)
+[import:25-40, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
 [import:12-16, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
@@ -207,7 +207,7 @@ In code, it looks like this:
   <img  class="center" src="code/scratch/dfs-stack.svg" width="400" />
 </p>
 {% sample lang="rs"%}
-[import:40-47, lang:"rust"](code/rust/tree.rs)
+[import:41-48, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
 [import:18-22, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}
@@ -252,7 +252,7 @@ And this is exactly what Breadth-First Search (BFS) does! On top of that, it can
   <img  class="center" src="code/scratch/bfs.svg" width="400" />
 </p>
 {% sample lang="rs"%}
-[import:49-57, lang:"rust"](code/rust/tree.rs)
+[import:50-58, lang:"rust"](code/rust/tree.rs)
 {% sample lang="hs"%}
 [import:24-28, lang:"haskell"](code/haskell/TreeTraversal.hs)
 {% sample lang="swift"%}


### PR DESCRIPTION
Destructuring an array using pattern matching makes the code more readable. This is a more idiomatic solution in Rust. 

This PR also adds a bit of space in the example to make it more readable in accordance with the [code style](https://github.com/algorithm-archivists/algorithm-archive/wiki/Code-style-guide) for the AAA.