### PR TITLE
Make README more readable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,32 @@
 
 The Arcane Algorithm Archive is a collaborative effort to create a guide for all important algorithms in all languages.
 This goal is obviously too ambitious for a book of any size, but it is a great project to learn from and work on and will hopefully become an incredible resource for programmers in the future.
-The book can be found here: https://www.algorithm-archive.org/.
-The GitHub repository can be found here: https://github.com/algorithm-archivists/algorithm-archive.
-Most algorithms have been covered on the YouTube channel LeiosOS: https://www.youtube.com/user/LeiosOS
-and live coded on Twitch: https://www.twitch.tv/simuleios.
-If you would like to communicate more directly, please feel free to go to our discord: https://discord.gg/Pr2E9S6.
 
+Here are some essential links:
+
+- Book / website: <https://www.algorithm-archive.org/>
+- GitHub repository: <https://github.com/algorithm-archivists/algorithm-archive>
+- YouTube channel (LeiosOS): <https://www.youtube.com/user/LeiosOS>
+- Twitch livestream (simuleios): <https://www.twitch.tv/simuleios>
+- Discord server: <https://discord.gg/Pr2E9S6>
 
 Note that this project is essentially a book about algorithms collaboratively written by an online community.
 Fortunately, there are a lot of algorithms out there, which means that there is a lot of content material available.
 Unfortunately, this means that we will probably never cover every algorithm ever created and instead need to focus on what the community sees as useful and necessary.
 That said, we'll still cover a few algorithms for fun that have very little, if any practical purpose.
 
-If you would like to contribute, feel free to go to any chapter with code associated with it and implement that algorithm in your favorite language,
-and then submit the code via pull request, following the submission guidelines found in `contents/how_to_contribute/how_to_contribute.md` (or [here](contents/how_to_contribute/how_to_contribute.md) if you are reading this on GitBook).
+If you would like to contribute, feel free to go to any chapter with code associated with it and implement that algorithm in your favorite language, and then submit the code via pull request.
+You can find help and instructions regarding the contribution process in our [How to Contribute](https://github.com/algorithm-archivists/algorithm-archive/wiki/How-to-Contribute) wiki entry.
 
 Hopefully, this project will grow and allow individuals to learn about and try their hand at implementing different algorithms for fun and (potentially) useful projects.
 If nothing else, it will be an enjoyable adventure for our community.
 
 Thanks for reading and let me know if there's anything wrong or if you want to see something implemented in the future!
 
-
 ----
 
 ## License
+
 The code examples for this project are licensed under the MIT license (found in [LICENSE.md](https://github.com/algorithm-archivists/algorithm-archive/blob/master/LICENSE.md)).
 All text content is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/legalcode) with attribution specified at the end of every chapter.
 All graphics are licensed under the license stated at the end of every chapter.


### PR DESCRIPTION
It always bothered me that the links in the second paragraph of the README are quite convoluted, so I went ahead and put them in a list. I also did made a few little other improvements.

### List of stuff I changed

- Use a list with short entries for the enumeration of links to other interesting sites/platforms/things in the second paragraph. (Review that influenced this part: https://github.com/algorithm-archivists/algorithm-archive/pull/574#discussion_r246228118)
- Use an absolute link to the How-to-Contribute wiki entry to make the sentence less convoluted. (Review that influenced this part: https://github.com/algorithm-archivists/algorithm-archive/pull/574#discussion_r246227846)
- Fix markdown style issues.
    - https://github.com/DavidAnson/markdownlint/blob/v0.11.0/doc/
      Rules.md#md012
    - https://github.com/DavidAnson/markdownlint/blob/v0.11.0/doc/
      Rules.md#md022
    - https://github.com/DavidAnson/markdownlint/blob/v0.11.0/doc/
      Rules.md#md034