### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,12 +45,12 @@ threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,12 +55,12 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting Julian Schacher at <jspp@posteo.net>. To report an issue
-involving him please contact James Schloss at <jrs.schloss@gmail.com>. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting Julian Schacher at <jspp@posteo.net> or James Schloss at
+<jrs.schloss@gmail.com>. All complaints will be reviewed and investigated and
+will result in a response that is deemed necessary and appropriate to the
+circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,82 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Julian Schacher at <jspp@posteo.net>. To report an issue
+involving him please contact James Schloss at <jrs.schloss@gmail.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## More Information
+
+More information regarding the Code of Conduct can be found in the
+[Code of Conduct wiki entry](https://github.com/algorithm-archivists/algorithm-archive/wiki/Code-of-Conduct).
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+[homepage]: <https://www.contributor-covenant.org>
+
+For answers to common questions about this code of conduct, see
+<https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md).
+By participating in this project you agree to abide by its terms.
+
+More information regarding the Code of Conduct can be found in the
+[Code of Conduct wiki entry](https://github.com/algorithm-archivists/algorithm-archive/wiki/Code-of-Conduct).
+
+## How to Contribute
+
 A contribution guide on how to contribute to the Arcane Algorithm Archive (AAA) can be found on this Wiki page: https://github.com/algorithm-archivists/algorithm-archive/wiki/How-to-Contribute
 
 The community member Buttercak3 also created a video series, explaining the contribution process of the AAA.  You can find a playlist with all videos here: https://www.youtube.com/playlist?list=PL5NSPcN6fRq2vwgdb9noJacF945CeBk8x


### PR DESCRIPTION
This PR adds a Code of Conduct.

## Rationale

The rationale for adding a Code of Conduct is well-described in the [Open Source Guide about Code of Conduct](https://opensource.guide/code-of-conduct/):

> A code of conduct is a document that establishes expectations for behavior for your project’s participants. Adopting, and enforcing, a code of conduct can help create a positive social atmosphere for your community.

More information regarding Code of Conduct can be found in the [very helpful aforementioned Open Source Guide](https://opensource.guide/code-of-conduct/).

## About the Code of Conduct itself

The Code of Conduct this PR adds is a modification of the [Contributor Covenant](https://www.contributor-covenant.org/), which is a popular Code of Conduct used by many big open source projects.
By using a modification of it, I'm following the advice (of the [Open Source guide](https://opensource.guide/code-of-conduct/)) to use prior art.

### Contact Persons

One modification is that I set two contact persons instead of just one. This is recommended by the [Open Source guide in section 3](https://opensource.guide/code-of-conduct/#deciding-how-youll-enforce-your-code-of-conduct). The reason is that people might want to report an issue, which involves the contact person itself.
So the primary contact person is me (@julianschacher) and the secondary contact person is @leios.

### More Information Section

Another modification is the addition of a link to an upcoming wiki entry, which holds more information regarding the Code of Conduct. More about the wiki entry at the bottom of this description.

## `CONTRIBUTING.md`

Two things get added to the `CONTRIBUTING.md`:
- A note that this project is released with a Code of Conduct and you agree to abide its terms by participating. By doing so, I follow the recommendation from the [Contributor Covenant website](https://www.contributor-covenant.org/).
- A link to the aforementioned wiki entry. More about the wiki entry at the bottom of this description.

## Useful Links

Here is a collection of links to useful resources regarding the Code of Conduct:

- <https://opensource.guide/code-of-conduct/>
- <https://www.contributor-covenant.org/>
- <https://www.contributor-covenant.org/faq>
- <https://www.contributor-covenant.org/version/1/4/code-of-conduct>

## Wiki Entry

I'll also add a wiki entry about the Code of Conduct, when this PR gets merged. Please feel free to comment your critique, suggestions and so on.
Here's a link to the wiki entry draft: <https://gist.github.com/julianschacher/4fc7258c8ed214dc9b07b2f2e442322f>