### PR TITLE
using isapprox(a,b) function in julia instead of rolling our own

### DIFF
--- a/contents/cooley_tukey/code/julia/fft.jl
+++ b/contents/cooley_tukey/code/julia/fft.jl
@@ -110,23 +110,17 @@ function butterfly(x)
     return y
 end
 
-function approx(x, y)
-    val = true
-    for i = 1:length(x)
-        if (abs(x[i]) - abs(y[i]) > 1e-5)
-            val = false
-        end
-    end
-    println(val)
-end
-
 function main()
     x = rand(128)
     y = cooley_tukey(x)
     z = iterative_cooley_tukey(x)
     w = fft(x)
-    approx(y, w)
-    approx(z, w)
+    if(isapprox(y, w))
+        println("Recursive Cooley Tukey matches fft() from FFTW package.")
+    end
+    if(isapprox(z, w))
+        println("Recursive Cooley Tukey matches fft() from FFTW package.")
+    end
 end
 
 main()

--- a/contents/cooley_tukey/code/julia/fft.jl
+++ b/contents/cooley_tukey/code/julia/fft.jl
@@ -119,7 +119,7 @@ function main()
         println("Recursive Cooley Tukey matches fft() from FFTW package.")
     end
     if(isapprox(z, w))
-        println("Recursive Cooley Tukey matches fft() from FFTW package.")
+        println("Iterative Cooley Tukey matches fft() from FFTW package.")
     end
 end
 


### PR DESCRIPTION
The julia implementation of fft had an approximate function we created ourselves, but there was no reason to do so when the `isapprox(a,b)` function exists