### PR TITLE
Kotlin capitalization fix

### DIFF
--- a/book.json
+++ b/book.json
@@ -192,6 +192,10 @@
         {
           "lang": "ss",
           "name": "Scheme"
+        },
+        {
+          "lang": "kotlin",
+          "name": "Kotlin"
         }
       ]
     }


### PR DESCRIPTION
Kotlin is a JVM-based language from JetBrains. Its name is fully capitalized on the Algorithm Archive website.

![image](https://user-images.githubusercontent.com/46641404/66462076-01017980-ea83-11e9-8c70-186c88e4ea8f.png)

This happened because its name is not in the [book.json](https://github.com/algorithm-archivists/algorithm-archive/blob/master/book.json) file.

The pull request adds Kotlin to book.json and fixes the issue.

![image](https://user-images.githubusercontent.com/46641404/66462318-7e2cee80-ea83-11e9-9a7f-0411995c8865.png)
