### PR TITLE
removing notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-> **IMPORTANT NOTE FOR NEW CONTRIBUTORS:**
->
-> We do **not** yet accept entirely new chapters by everyone. If you would like to start working on one, please contact James Schloss (Leios) first. If you create a full chapter, including text, and submit it as a pull request it is most likely going to get rejected.
->
-> If you want to help, it is best to write language examples for *existing* chapters. You can also try to find spelling or other mistakes in existing chapters and submit fixes for those.
-
 # The Arcane Algorithm Archive
 
 The Arcane Algorithm Archive is a collaborative effort to create a guide for all important algorithms in all languages.


### PR DESCRIPTION
This PR will remove the notice at the start of the Algorithm Archive specifying that we no longer accept new chapters. From here on, we should have no problem merging new chapters because the licensing has been completed and I have time to review again.

Let me know if anyone has any problems with this. This marks a slightly different design methodology for the AAA moving forward where I am not longer the only author.