### PR TITLE
adding FUNDING.yml file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: leios
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
I was recently accepted into the github sponsors program and would like to add a funding button here and also potentially on the front page. As this is a somewhat significant change to the AAA, it is worth discussing a bit.

This would involve adding a new chapter for sponsors and such and on the main page as well. I am up for editing the current tiers as well, so let me know if you think of better reward tiers: https://github.com/sponsors/leios

