### PR TITLE
A couple of GoLang code improvements

### DIFF
--- a/contents/bogo_sort/code/go/bogo_sort.go
+++ b/contents/bogo_sort/code/go/bogo_sort.go
@@ -8,10 +8,10 @@ import (
     "time"
 )
 
-func shuffle(a *[]int) {
-    for i := len(*a) - 1; i > 0; i-- {
+func shuffle(a []int) {
+    for i := len(a) - 1; i > 0; i-- {
         j := rand.Intn(i + 1)
-        (*a)[i], (*a)[j] = (*a)[j], (*a)[i]
+        a[i], a[j] = a[j], a[i]
     }
 }
 
@@ -24,8 +24,8 @@ func isSorted(a []int) bool {
     return true
 }
 
-func bogoSort(a *[]int) {
-    for !isSorted(*a) {
+func bogoSort(a []int) {
+    for !isSorted(a) {
         shuffle(a)
     }
 }
@@ -33,6 +33,6 @@ func bogoSort(a *[]int) {
 func main() {
     rand.Seed(time.Now().UnixNano())
     a := []int{1, 3, 4, 2}
-    bogoSort(&a)
+    bogoSort(a)
     fmt.Println(a)
 }

--- a/contents/jarvis_march/code/golang/jarvis.go
+++ b/contents/jarvis_march/code/golang/jarvis.go
@@ -21,7 +21,7 @@ func leftMostPoint(points []point) point {
 }
 
 func (p point) equal(o point) bool {
-	return p.x == o.x && p.y == o.x
+	return p.x == o.x && p.y == o.y
 }
 
 func counterClockWise(p1, p2, p3 point) bool {


### PR DESCRIPTION
bogo_sort - there was no need for references everywhere, because a slice is a pointer by nature (values can be changed) and the code doesn't use append or anything else that would change the size, and, possibly, the initial address of the slice

jarvis - the equal function had a typo, perhaps the example should be improved, in the future, to catch this case