### PR TITLE
Regularize lang markers

### DIFF
--- a/contents/bubble_sort/bubble_sort.md
+++ b/contents/bubble_sort/bubble_sort.md
@@ -74,7 +74,7 @@ This means that we need to go through the vector $$\mathcal{O}(n^2)$$ times with
 <p>
   <img  class="center" src="code/scratch/bubble_sort.svg" width="400" />
 </p>
-{% sample lang="coffeescript" %}
+{% sample lang="coffee" %}
 [import:1-6, lang:"coffeescript"](code/coffeescript/bubblesort.coffee)
 {% endmethod %}
 
@@ -153,7 +153,7 @@ Trust me, there are plenty of more complicated algorithms that do precisely the 
 [import, lang:"v"](code/v/bubble_sort.v)
 {% sample lang="scratch" %}
 The code snippet was taken from this [Scratch project](https://scratch.mit.edu/projects/316483792)
-{% sample lang="coffeescript" %}
+{% sample lang="coffee" %}
 [import, lang:"coffeescript"](code/coffeescript/bubblesort.coffee)
 {% endmethod %}
 

--- a/contents/euclidean_algorithm/euclidean_algorithm.md
+++ b/contents/euclidean_algorithm/euclidean_algorithm.md
@@ -23,7 +23,7 @@ The algorithm is a simple way to find the *greatest common divisor* (GCD) of two
 [import:3-12, lang="lisp"](code/clisp/euclidean.lisp)
 {% sample lang="py" %}
 [import:11-22, lang="python"](code/python/euclidean_example.py)
-{% sample lang="haskell" %}
+{% sample lang="hs" %}
 [import:2-8, lang="haskell"](code/haskell/euclidean_example.hs)
 {% sample lang="rs" %}
 [import:3-15, lang="rust"](code/rust/euclidean_example.rs)
@@ -33,7 +33,7 @@ The algorithm is a simple way to find the *greatest common divisor* (GCD) of two
 [import:25-38, lang="go"](code/go/euclidean.go)
 {% sample lang="swift" %}
 [import:1-14, lang="swift"](code/swift/euclidean_algorithm.swift)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 [import:3-17, lang="matlab"](code/matlab/euclidean.m)
 {% sample lang="lua" %}
 [import:1-14, lang="lua"](code/lua/euclidean.lua)
@@ -109,7 +109,7 @@ Modern implementations, though, often use the modulus operator (%) like so
 [import:14-18, lang="lisp"](code/clisp/euclidean.lisp)
 {% sample lang="py" %}
 [import:1-9, lang="python"](code/python/euclidean_example.py)
-{% sample lang="haskell" %}
+{% sample lang="hs" %}
 [import:10-14, lang="haskell"](code/haskell/euclidean_example.hs)
 {% sample lang="rs" %}
 [import:17-27, lang="rust"](code/rust/euclidean_example.rs)
@@ -119,7 +119,7 @@ Modern implementations, though, often use the modulus operator (%) like so
 [import:14-23, lang="go"](code/go/euclidean.go)
 {% sample lang="swift" %}
 [import:16-27, lang="swift"](code/swift/euclidean_algorithm.swift)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 [import:19-31, lang="matlab"](code/matlab/euclidean.m)
 {% sample lang="lua" %}
 [import:16-25, lang="lua"](code/lua/euclidean.lua)
@@ -206,7 +206,7 @@ Here's a video on the Euclidean algorithm:
 [import, lang="lisp"](code/clisp/euclidean.lisp)
 {% sample lang="py" %}
 [import, lang="python"](code/python/euclidean_example.py)
-{% sample lang="haskell" %}
+{% sample lang="hs" %}
 [import, lang="haskell"](code/haskell/euclidean_example.hs)
 {% sample lang="rs" %}
 [import, lang="rust"](code/rust/euclidean_example.rs)
@@ -216,7 +216,7 @@ Here's a video on the Euclidean algorithm:
 [import, lang="go"](code/go/euclidean.go)
 {% sample lang="swift" %}
 [import, lang="swift"](code/swift/euclidean_algorithm.swift)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 [import, lang="matlab"](code/matlab/euclidean.m)
 {% sample lang="lua" %}
 [import, lang="lua"](code/lua/euclidean.lua)

--- a/contents/monte_carlo_integration/monte_carlo_integration.md
+++ b/contents/monte_carlo_integration/monte_carlo_integration.md
@@ -142,13 +142,13 @@ Feel free to submit your version via pull request, and thanks for reading!
 [import, lang:"javascript"](code/javascript/monte_carlo.js)
 {% sample lang="hs" %}
 [import, lang:"haskell"](code/haskell/monteCarlo.hs)
-{%sample lang="rs" %}
+{% sample lang="rs" %}
 [import, lang:"rust"](code/rust/monte_carlo.rs)
-{%sample lang="d" %}
+{% sample lang="d" %}
 [import, lang:"d"](code/d/monte_carlo.d)
-{%sample lang="go" %}
+{% sample lang="go" %}
 [import, lang:"go"](code/go/monteCarlo.go)
-{%sample lang="r" %}
+{% sample lang="r" %}
 [import, lang:"r"](code/r/monte_carlo.R)
 {% sample lang="java" %}
 [import, lang:"java"](code/java/MonteCarlo.java)

--- a/contents/thomas_algorithm/thomas_algorithm.md
+++ b/contents/thomas_algorithm/thomas_algorithm.md
@@ -119,7 +119,7 @@ You will find this algorithm implemented [in this project](https://scratch.mit.e
 [import, lang:"swift"](code/swift/thomas.swift)
 {% sample lang="php" %}
 [import, lang:"php"](code/php/thomas.php)
-{%sample lang="nim" %}
+{% sample lang="nim" %}
 [import, lang:"nim"](code/nim/thomas_algorithm.nim)
 {% sample lang="cpp" %}
 [import, lang:"cpp"](code/c++/thomas.cpp)

--- a/contents/tree_traversal/tree_traversal.md
+++ b/contents/tree_traversal/tree_traversal.md
@@ -22,13 +22,13 @@ As a note, a `node` struct is not necessary in javascript, so this is an example
 <p>
   <img  class="center" src="code/scratch/struct.svg" width="250" />
 </p>
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import:4-7, lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import:1-4, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import:1-9, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import:4-37, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import:1-5, lang:"crystal"](code/crystal/tree-traversal.cr)
@@ -62,13 +62,13 @@ Because of this, the most straightforward way to traverse the tree might be recu
   <img  class="center" src="code/scratch/dfs.svg" width="250" />
   <img  class="center" src="code/scratch/dfs-from.svg" width="250" />
 </p>
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import:9-15 lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import:6-7, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import:24-30, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import:41-49, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import:7-10, lang:"crystal"](code/crystal/tree-traversal.cr)
@@ -110,13 +110,13 @@ Now, in this case the first element searched through is still the root of the tr
 <p>
   <img  class="center" src="code/scratch/dfs-post.svg" width="300" />
 </p>
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import:17-24, lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import:9-10, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import:32-38, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import:51-57, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import:12-15, lang:"crystal"](code/crystal/tree-traversal.cr)
@@ -153,13 +153,13 @@ In this case, the first node visited is at the bottom of the tree and moves up t
 <p>
   <img  class="center" src="code/scratch/dfs-in.svg" width="300" />
 </p>
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import:25-40, lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import:12-16, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import:40-53, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import:59-78, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import:17-31, lang:"crystal"](code/crystal/tree-traversal.cr)
@@ -206,13 +206,13 @@ In code, it looks like this:
 <p>
   <img  class="center" src="code/scratch/dfs-stack.svg" width="400" />
 </p>
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import:41-48, lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import:18-22, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import:55-67, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import:80-91, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import:33-41, lang:"crystal"](code/crystal/tree-traversal.cr)
@@ -251,13 +251,13 @@ And this is exactly what Breadth-First Search (BFS) does! On top of that, it can
 <p>
   <img  class="center" src="code/scratch/bfs.svg" width="400" />
 </p>
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import:50-58, lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import:24-28, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import:69-81, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import:93-104, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import:43-51, lang:"crystal"](code/crystal/tree-traversal.cr)
@@ -306,13 +306,13 @@ Here is a video describing tree traversal:
 
 The code snippets were taken from this [Scratch project](https://scratch.mit.edu/projects/174017753/)
 
-{% sample lang="rs"%}
+{% sample lang="rs" %}
 [import, lang:"rust"](code/rust/tree.rs)
-{% sample lang="hs"%}
+{% sample lang="hs" %}
 [import, lang:"haskell"](code/haskell/TreeTraversal.hs)
-{% sample lang="swift"%}
+{% sample lang="swift" %}
 [import, lang:"swift"](code/swift/tree.swift)
-{% sample lang="php"%}
+{% sample lang="php" %}
 [import, lang:"php"](code/php/tree_traversal.php)
 {% sample lang="crystal" %}
 [import, lang:"crystal"](code/crystal/tree-traversal.cr)

--- a/contents/verlet_integration/verlet_integration.md
+++ b/contents/verlet_integration/verlet_integration.md
@@ -45,13 +45,13 @@ Here is what it looks like in code:
 {% sample lang="scratch" %}
 Unfortunately, this has not yet been implemented in scratch, so here's Julia code:
 [import:1-13, lang:"julia"](code/julia/verlet.jl)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 Unfortunately, this has not yet been implemented in matlab, so here's Julia code:
 [import:1-13, lang:"julia"](code/julia/verlet.jl)
 {% sample lang="LabVIEW" %}
 Unfortunately, this has not yet been implemented in LabVIEW, so here's Julia code:
 [import:1-13, lang:"julia"](code/julia/verlet.jl)
-{% sample lang="javascript" %}
+{% sample lang="js" %}
 [import:1-14, lang:"javascript"](code/javascript/verlet.js)
 {% sample lang="rs" %}
 [import:1-13, lang:"rust"](code/rust/verlet.rs)
@@ -103,13 +103,13 @@ However, the error for this is $$\mathcal{O}(\Delta t)$$, which is quite poor, b
 {% sample lang="scratch" %}
 Unfortunately, this has not yet been implemented in scratch, so here's Julia code:
 [import:15-31, lang:"julia"](code/julia/verlet.jl)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 Unfortunately, this has not yet been implemented in matlab, so here's Julia code:
 [import:15-31, lang:"julia"](code/julia/verlet.jl)
 {% sample lang="LabVIEW" %}
 Unfortunately, this has not yet been implemented in LabVIEW, so here's Julia code:
 [import:15-31, lang:"julia"](code/julia/verlet.jl)
-{% sample lang="javascript" %}
+{% sample lang="js" %}
 [import:16-32, lang:"javascript"](code/javascript/verlet.js)
 {% sample lang="rs" %}
 [import:15-32, lang:"rust"](code/rust/verlet.rs)
@@ -175,13 +175,13 @@ Here is the velocity Verlet method in code:
 {% sample lang="scratch" %}
 Unfortunately, this has not yet been implemented in scratch, so here's Julia code:
 [import:33-45, lang:"julia"](code/julia/verlet.jl)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 Unfortunately, this has not yet been implemented in matlab, so here's Julia code:
 [import:33-45, lang:"julia"](code/julia/verlet.jl)
 {% sample lang="LabVIEW" %}
 Unfortunately, this has not yet been implemented in LabVIEW, so here's Julia code:
 [import:33-45, lang:"julia"](code/julia/verlet.jl)
-{% sample lang="javascript" %}
+{% sample lang="js" %}
 [import:34-45, lang:"javascript"](code/javascript/verlet.js)
 {% sample lang="rs" %}
 [import:34-45, lang:"rust"](code/rust/verlet.rs)
@@ -237,14 +237,14 @@ Submitted by Jie
     <img  class="center" src="code/scratch/verlet_scratch.png" />
 </p>
 Link: [https://scratch.mit.edu/projects/173039394/](https://scratch.mit.edu/projects/173039394/)
-{% sample lang="matlab" %}
+{% sample lang="m" %}
 [import, lang:"matlab"](code/matlab/verlet.m)
 {% sample lang="LabVIEW" %}
 Submitted by P. Mekhail
 <p>
     <img  class="center" src="code/labview/verlet_labview.png" />
 </p>
-{% sample lang="javascript" %}
+{% sample lang="js" %}
 [import, lang:"javascript"](code/javascript/verlet.js)
 {% sample lang="rs" %}
 [import, lang:"rust"](code/rust/verlet.rs)


### PR DESCRIPTION
PR to "regularize" language markers.

## Description of problem

If someone selected a specific language in a specific chapter, for certain languages, the language would not be carried over to certain other chapters, even though an implementation in the same language would exist. Like, if one was looking at the C implementation of Bogo Sort, then he moved on to Euclidean Algorithm. The archive would still show the C implementation here instead of the default. But this doesn't work for certain languages. The problem is regarding the inconsistency in the tags used for the lang markers in the markdown files for each chapter (i.e. the `{% sample lang="<language>" %}` for the sample). So, I changed the language markers for these files so that the language carries over to different files, for the separate markers.

## Changes

- Euclidean Algorithm: `"haskell"` -> `"hs"`
- Verlet Integration: `"javascript"` -> `"js"`
- Verlet Integration, Euclidean Algorithm: `"matlab"` -> `"m"`

**Before The Change:** If one was to look at the Verlet Integration implementation in JavaScript, and then move to (for example) BogoSort, instead of showing the existing JavaScript implementation (as expected), it would show the default for the languages (that is Julia). Such problem occured for any of the listed languages in the implementations listed in the changes section.

**Note:** I did some extra small tweaks, and notices some inconsistencies.

- I changed `"coffeescript"` language marker to `"coffee"`, as `"coffeescript"` was not specified in `book.json` file for CoffeeScript language.
- Although implementations of certain algorithms in Brainfuck, gnuplot, Ruby, and Smalltalk exist, there are no corresponding entries in the `book.json` file.
- Certain laguage markers were such that whitespaces were missing before or after the `%` symbol, so for consistency sake, I changed them. Please take a look at the commits for specific change details.
- I have posted an issue regarding this bug. Link: https://github.com/algorithm-archivists/algorithm-archive/issues/670