### PR TITLE
modifying gauss's easter algorithm to always output strings

### DIFF
--- a/contents/computus/code/crystal/gauss_easter.cr
+++ b/contents/computus/code/crystal/gauss_easter.cr
@@ -19,7 +19,7 @@ def computus(year, servois = false)
 
   # Returning if user wants value for Servois' table
   if servois
-    return (21 + d) % 31
+    return ((21 + d) % 31).to_s
   end
 
   # Finding the next Sunday

--- a/contents/computus/code/crystal/gauss_easter.cr
+++ b/contents/computus/code/crystal/gauss_easter.cr
@@ -57,7 +57,7 @@ def main
        "notation) and the date of Easter for 2020-2030 AD:"
   puts "Year\tServois number\tEaster"
   a.each_index { |i|
-    puts "#{a[i]}\t#{servois_numbers[i]}\t\t\t\t#{easter_dates[i]}"
+    puts "#{a[i]}\t#{servois_numbers[i]}\t\t#{easter_dates[i]}"
   }
 end
 

--- a/contents/computus/code/julia/gauss_easter.jl
+++ b/contents/computus/code/julia/gauss_easter.jl
@@ -20,7 +20,7 @@ function computus(year; servois=false)
 
     # Returning if user wants value for Servois' table
     if servois
-        return mod(21 + d,31)
+        return string(mod(21 + d,31))
     end
 
     # Finding the next Sunday
@@ -58,5 +58,5 @@ println("The following are the dates of the Paschal full moon (using Servois " *
         "notation) and the date of Easter for 2020-2030 AD:")
 println("Year\tServois number\tEaster")
 for i = 1:length(a)
-    println("$(a[i])\t$(servois_numbers[i])\t\t\t\t$(easter_dates[i])")
+    println("$(a[i])\t$(servois_numbers[i])\t\t$(easter_dates[i])")
 end

--- a/contents/computus/code/python/gauss_easter.py
+++ b/contents/computus/code/python/gauss_easter.py
@@ -19,7 +19,7 @@ def computus(year, servois=False):
 
     # Returning if user wants value for Servois' table
     if servois:
-        return (21 + d) % 31
+        return str((21 + d) % 31)
 
     # Finding the next Sunday
     # Century-based offset in weekly calculation
@@ -52,4 +52,4 @@ print(
 )
 print("Year\tServois number\tEaster")
 for year in range(2020, 2031):
-    print(f"{year}\t{computus(year, servois=True)}\t{computus(year)}")
+    print(f"{year}\t{computus(year, servois=True)}\t\t{computus(year)}")


### PR DESCRIPTION
There is no reason for the return types to be different if you are returning the number needed for Servios' table.

As a note, we probably need a better way of displaying the table at the end because tab spacing is inconsistent on different terminal emulators