### PR TITLE
Add Thomas Algorithm in Rust

### DIFF
--- a/contents/thomas_algorithm/code/rust/thomas.rs
+++ b/contents/thomas_algorithm/code/rust/thomas.rs
@@ -1,0 +1,38 @@
+// This implementation is based on the C++ implementation.
+
+fn thomas(a: &[f64], b: &[f64], c: &[f64], x: &mut Vec<f64>) {
+    let size = a.len();
+    let mut y = vec![0.0; size];
+
+    y[0] = c[0] / b[0];
+    x[0] /= b[0];
+
+    for i in 1..size {
+        let scale = 1.0 / (b[i] - a[i] * y[i - 1]);
+        y[i] = c[i] * scale;
+        let x_i = x[i];
+        x[i] = (x_i - a[i] * x[i - 1]) * scale;
+    }
+
+    for i in (0..(size - 1)).rev() {
+        x[i] -= y[i] * x[i + 1];
+    }
+}
+
+fn main() {
+    let a = vec![0.0, 2.0, 3.0];
+    let b = vec![1.0, 3.0, 6.0];
+    let c = vec![4.0, 5.0, 0.0];
+    let mut x = vec![7.0, 5.0, 3.0];
+
+    println!("The system");
+    println!("[{:?} {:?} {:?}][x] = [{:?}]", a[0], b[0], c[0], &x[0]);
+    println!("[{:?} {:?} {:?}][x] = [{:?}]", a[1], b[1], c[1], &x[1]);
+    println!("[{:?} {:?} {:?}][x] = [{:?}]", a[2], b[2], c[2], &x[2]);
+    println!("has the solution");
+
+    thomas(&a, &b, &c, &mut x);
+
+    x.iter()
+        .for_each(|i| println!("[{:>19}]", format!("{:18}", format!("{:?}", i))));
+}

--- a/contents/thomas_algorithm/code/rust/thomas.rs
+++ b/contents/thomas_algorithm/code/rust/thomas.rs
@@ -1,5 +1,3 @@
-// This implementation is based on the C++ implementation.
-
 fn thomas(a: &[f64], b: &[f64], c: &[f64], x: &mut Vec<f64>) {
     let size = a.len();
     let mut y = vec![0.0; size];

--- a/contents/thomas_algorithm/code/rust/thomas.rs
+++ b/contents/thomas_algorithm/code/rust/thomas.rs
@@ -1,27 +1,29 @@
-fn thomas(a: &[f64], b: &[f64], c: &[f64], x: &mut Vec<f64>) {
+fn thomas(a: &[f64], b: &[f64], c: &[f64], x: &[f64]) -> Vec<f64> {
     let size = a.len();
     let mut y = vec![0.0; size];
+    let mut z = Vec::from(x);
 
     y[0] = c[0] / b[0];
-    x[0] /= b[0];
+    z[0] = x[0] / b[0];
 
     for i in 1..size {
         let scale = 1.0 / (b[i] - a[i] * y[i - 1]);
         y[i] = c[i] * scale;
-        let x_i = x[i];
-        x[i] = (x_i - a[i] * x[i - 1]) * scale;
+        z[i] = (z[i] - a[i] * z[i - 1]) * scale;
     }
 
     for i in (0..(size - 1)).rev() {
-        x[i] -= y[i] * x[i + 1];
+        z[i] -= y[i] * z[i + 1];
     }
+
+    z
 }
 
 fn main() {
     let a = vec![0.0, 2.0, 3.0];
     let b = vec![1.0, 3.0, 6.0];
     let c = vec![4.0, 5.0, 0.0];
-    let mut x = vec![7.0, 5.0, 3.0];
+    let x = vec![7.0, 5.0, 3.0];
 
     println!("The system");
     println!("[{:?} {:?} {:?}][x] = [{:?}]", a[0], b[0], c[0], &x[0]);
@@ -29,8 +31,8 @@ fn main() {
     println!("[{:?} {:?} {:?}][x] = [{:?}]", a[2], b[2], c[2], &x[2]);
     println!("has the solution");
 
-    thomas(&a, &b, &c, &mut x);
+    let y = thomas(&a, &b, &c, &x);
 
-    x.iter()
+    y.iter()
         .for_each(|i| println!("[{:>19}]", format!("{:18}", format!("{:?}", i))));
 }

--- a/contents/thomas_algorithm/thomas_algorithm.md
+++ b/contents/thomas_algorithm/thomas_algorithm.md
@@ -133,6 +133,8 @@ You will find this algorithm implemented [in this project](https://scratch.mit.e
 [import, lang="ruby"](code/ruby/thomas.rb)
 {% sample lang="js" %}
 [import, lang:"javascript"](code/javascript/thomas.js)
+{% sample lang="rs" %}
+[import, lang:"rust"](code/rust/thomas.rs)
 {% endmethod %}
 
 <script>


### PR DESCRIPTION
For leios: This one is implemented without any external crates, so you can compile it just with `rustc`. (Let me know if what I did for pretty-printing on line 37 of the code was too much.)