### PR TITLE
Add IFS in python

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,9 +42,10 @@ This file lists everyone, who contributed to this repo and wanted to show up her
 - Christopher Milan
 - Vexatos
 - Raven-Blue Dragon
-- Björn Heinrichs 
+- Björn Heinrichs
 - Olav Sundfør
 - Ben Chislett
 - dovisutu
 - Antetokounpo
 - Akash Dhiman
+- Jonathan D. B. Van Schenck

--- a/contents/IFS/IFS.md
+++ b/contents/IFS/IFS.md
@@ -128,6 +128,8 @@ Here, instead of tracking children of children, we track a single individual tha
 {% method %}
 {% sample lang="jl" %}
 [import:4-17, lang:"julia"](code/julia/IFS.jl)
+{% sample lang="py" %}
+[import:5-13, lang:"python"](code/python/IFS.py)
 {% endmethod %}
 
 If we set the initial points to the on the equilateral triangle we saw before, we can see the Sierpinski triangle again after a few thousand iterations, as shown below:
@@ -180,6 +182,8 @@ In addition, we have written the chaos game code to take in a set of points so t
 {% method %}
 {% sample lang="jl" %}
 [import, lang:"julia"](code/julia/IFS.jl)
+{% sample lang="py" %}
+[import, lang:"python"](code/python/IFS.py)
 {% endmethod %}
 
 ### Bibliography

--- a/contents/IFS/IFS.md
+++ b/contents/IFS/IFS.md
@@ -129,7 +129,7 @@ Here, instead of tracking children of children, we track a single individual tha
 {% sample lang="jl" %}
 [import:4-17, lang:"julia"](code/julia/IFS.jl)
 {% sample lang="py" %}
-[import:5-13, lang:"python"](code/python/IFS.py)
+[import:5-12, lang:"python"](code/python/IFS.py)
 {% endmethod %}
 
 If we set the initial points to the on the equilateral triangle we saw before, we can see the Sierpinski triangle again after a few thousand iterations, as shown below:

--- a/contents/IFS/IFS.md
+++ b/contents/IFS/IFS.md
@@ -131,7 +131,7 @@ Here, instead of tracking children of children, we track a single individual tha
 {% sample lang="cpp" %}
 [import:39-52, lang:"cpp"](code/c++/IFS.cpp)
 {% sample lang="py" %}
-[import:1-12, lang:"python"](code/python/IFS.py)
+[import:5-12, lang:"python"](code/python/IFS.py)
 {% endmethod %}
 
 If we set the initial points to the on the equilateral triangle we saw before, we can see the Sierpinski triangle again after a few thousand iterations, as shown below:

--- a/contents/IFS/IFS.md
+++ b/contents/IFS/IFS.md
@@ -179,7 +179,7 @@ In addition, we have written the chaos game code to take in a set of points so t
 
 {% method %}
 {% sample lang="jl" %}
-[import:4-17, lang:"julia"](code/julia/IFS.jl)
+[import, lang:"julia"](code/julia/IFS.jl)
 {% endmethod %}
 
 ### Bibliography

--- a/contents/IFS/IFS.md
+++ b/contents/IFS/IFS.md
@@ -131,7 +131,7 @@ Here, instead of tracking children of children, we track a single individual tha
 {% sample lang="cpp" %}
 [import:39-52, lang:"cpp"](code/c++/IFS.cpp)
 {% sample lang="py" %}
-[import:5-12, lang:"python"](code/python/IFS.py)
+[import:1-12, lang:"python"](code/python/IFS.py)
 {% endmethod %}
 
 If we set the initial points to the on the equilateral triangle we saw before, we can see the Sierpinski triangle again after a few thousand iterations, as shown below:

--- a/contents/IFS/code/python/IFS.py
+++ b/contents/IFS/code/python/IFS.py
@@ -1,24 +1,34 @@
 from random import random, choice
-from math import sqrt
+from math import sqrt, sin, cos, pi
 
-# This is a function to simulate a "chaos game"
-def chaos_game(n, shape_points, output_file = "out.dat"):
+# This generator simulates a "chaos game"
+def chaos_game(n, shape_points):
     # Initialize the starting point
     point = [random(), random()]
 
-    with open(output_file, "w") as f:
-        for _ in range(n):
-            # Update the point position and write it to the file
-            point = [(_p + _s) / 2 for _p, _s in zip(point, choice(shape_points))]
-            f.write(",".join([str(_p) for _p in point]) + '\n')
+    for _ in range(n):
+        # Update the point position and yield the result
+        point = [(_p + _s) / 2 for _p, _s in zip(point, choice(shape_points))]
+        yield point
+
+# This function generates the shape points for an N-gon inscribed inside a
+#  unit circle, with one of the edges oriented along the bottom
+def ngon_shape_points(N):
+    # Exterior N-gon angle
+    phi = 2 * pi / N
+
+    # Offset to put an edge at the bottom
+    delta = (pi + phi) / 2
+
+    return [[cos(- delta - m * phi), sin(- delta - m * phi)] for m in range(N)]
 
 # This will generate a Sierpinski triangle with a chaos game of n points for an
-# initial triangle with three points on the vertices of an equilateral triangle:
-#     A = (0.0, 0.0)
-#     B = (0.5, sqrt(0.75))
-#     C = (1.0, 0.0)
+# initial equilateral triangle inscribed on a unit circle. The shape points are:
+#     A = (-sqrt(3)/2, -0.5)
+#     B = (       0.0,  1.0)
+#     C = ( sqrt(3)/2, -0.5)
 # It will output the file sierpinski.dat, which can be plotted after
-shape_points = [[0.0, 0.0],
-                [0.5, sqrt(0.75)],
-                [1.0, 0.0]]
-chaos_game(10000, shape_points, 'sierpinski.dat')
+shape_points = ngon_shape_points(3)
+with open("sierpinski.dat", "w") as f:
+    for point in chaos_game(10000, shape_points):
+        f.write("{0},{1}\n".format(*point))

--- a/contents/IFS/code/python/IFS.py
+++ b/contents/IFS/code/python/IFS.py
@@ -1,0 +1,24 @@
+from random import random, choice
+from math import sqrt
+
+# This is a function to simulate a "chaos game"
+def chaos_game(n, shape_points, output_file = "out.dat"):
+    # Initialize the starting point
+    point = [random(), random()]
+
+    with open(output_file, "w") as f:
+        for _ in range(n):
+            # Update the point position and write it to the file
+            point = [_p + _s for _p, _s in zip(point, choice(shape_points))]
+            f.write(",".join([str(_p) for _p in p]) + '\n')
+
+# This will generate a Sierpinski triangle with a chaos game of n points for an
+# initial triangle with three points on the vertices of an equilateral triangle:
+#     A = (0.0, 0.0)
+#     B = (0.5, sqrt(0.75))
+#     C = (1.0, 0.0)
+# It will output the file sierpinski.dat, which can be plotted after
+shape_points = [[0.0, 0.0],
+                [0.5, sqrt(0.75)],
+                [1.0, 0.0]]
+chaos_game(10000, shape_points, 'sierpinski.dat')

--- a/contents/IFS/code/python/IFS.py
+++ b/contents/IFS/code/python/IFS.py
@@ -9,8 +9,8 @@ def chaos_game(n, shape_points, output_file = "out.dat"):
     with open(output_file, "w") as f:
         for _ in range(n):
             # Update the point position and write it to the file
-            point = [_p + _s for _p, _s in zip(point, choice(shape_points))]
-            f.write(",".join([str(_p) for _p in p]) + '\n')
+            point = [(_p + _s) / 2 for _p, _s in zip(point, choice(shape_points))]
+            f.write(",".join([str(_p) for _p in point]) + '\n')
 
 # This will generate a Sierpinski triangle with a chaos game of n points for an
 # initial triangle with three points on the vertices of an equilateral triangle:

--- a/contents/IFS/code/python/IFS.py
+++ b/contents/IFS/code/python/IFS.py
@@ -1,5 +1,5 @@
 from random import random, choice
-from math import sqrt, sin, cos, pi
+from math import sqrt
 
 # This generator simulates a "chaos game"
 def chaos_game(n, shape_points):
@@ -8,7 +8,7 @@ def chaos_game(n, shape_points):
 
     for _ in range(n):
         # Update the point position and yield the result
-        point = [(_p + _s) / 2 for _p, _s in zip(point, choice(shape_points))]
+        point = [(p + s) / 2 for p, s in zip(point, choice(shape_points))]
         yield point
 
 # This will generate a Sierpinski triangle with a chaos game of n points for an
@@ -22,4 +22,4 @@ shape_points = [[0.0, 0.0],
                 [1.0, 0.0]]
 with open("sierpinski.dat", "w") as f:
     for point in chaos_game(10000, shape_points):
-        f.write("{0},{1}\n".format(*point))
+        f.write("{0}\t{1}\n".format(*point))


### PR DESCRIPTION
I tried to adapt the julia code as closely as possible, with just a few python-specific tweaks.
I opted to only use base python packages so that the code would be usable for more people (with numpy, I think this is a one-liner).
Additionally, I intentionally used some python specific syntax and structuring (like "[x for x in y]" list comprehension and the zip function, etc) because I felt it was truer to the language, than doing the usually thing of making a full for loop block that loops over an index. This whole thing would be much cleaner if base python had element-wise addition. . . *sigh*