### PR TITLE
Update Julia Jarvis March to use points from Graham Scan

### DIFF
--- a/contents/jarvis_march/code/julia/jarvis.jl
+++ b/contents/jarvis_march/code/julia/jarvis.jl
@@ -48,8 +48,11 @@ function jarvis_march(points::Vector{Pos})
 end
 
 function main()
-
-    points = [Pos(2,1.5), Pos(1, 1), Pos(2, 4), Pos(3, 1)]
+    points = [
+        Pos(-5, 2), Pos(5, 7), Pos(-6, -12), Pos(-14, -14), Pos(9, 9),
+        Pos(-1, -1), Pos(-10, 11), Pos(-6, 15), Pos(-6, -8), Pos(15, -9),
+        Pos(7, -7), Pos(-2, -9), Pos(6, -5), Pos(0, 14), Pos(2, 8)
+    ]
     hull = jarvis_march(points)
     println(hull)
 end


### PR DESCRIPTION
This uses the points from https://github.com/algorithm-archivists/algorithm-archive/blob/4313e7eb3d2faa152590c631d180d06a5c85f46d/contents/graham_scan/code/julia/graham.jl#L50

It revealed a bug in this implementation that needs to be fixed.