### PR TITLE
Update Travis for HonKit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,10 @@ node_js:
   - "12"
 
 before_script:
-  - mkdir -p "${TRAVIS_BUILD_DIR}"/build
-  - CHANGED_FILES=$(git diff --name-only HEAD~1...HEAD .)
-  - |
-      if echo $CHANGED_FILES | grep "package.json"
-      then
-        cp package.json "${TRAVIS_BUILD_DIR}"/build
-      fi
+  - BOOK_BUILD_DIR="${TRAVIS_BUILD_DIR}"/_book
 
 script:
-  - |
-      if echo $CHANGED_FILES | grep "package.json"
-      then
-        npm build --reload . ${TRAVIS_BUILD_DIR}/build
-      else
-        npm build . ${TRAVIS_BUILD_DIR}/build
-      fi
+  - npm run build
 
 after_success:
     - |

--- a/tools/deploy/update_site_travis.bash
+++ b/tools/deploy/update_site_travis.bash
@@ -33,15 +33,13 @@ git config user.email "travis@travis-ci.org"
 
 GH_REPO_REF="github.com/${DOCS_REPO_OWNER}/${DOCS_REPO_NAME}.git"
 
-# Assume the book has already been built, and was moved to `_book/`
-# inside the same directory as this script.
-book_build_dir=_book
+# Assume the book has already been built and lives in $BOOK_BUILD_DIR.
 
-if [ -d "${book_build_dir}" ]; then
+if [ -d "${BOOK_BUILD_DIR}" ]; then
     echo "${bold}Cloning the website repo...${normal}"
     git clone -b "${DOCS_BRANCH_NAME}" https://git@"${GH_REPO_REF}"
     rm -rf ./"${DOCS_REPO_NAME}"/*
-    cp -a ./"${book_build_dir}"/* ./"${DOCS_REPO_NAME}"
+    cp -a "${BOOK_BUILD_DIR}"/* ./"${DOCS_REPO_NAME}"
     pushd ./"${DOCS_REPO_NAME}"
     echo "www.algorithm-archive.org" > CNAME
     echo "${bold}Adding changes...${normal}"

--- a/tools/deploy/update_site_travis.bash
+++ b/tools/deploy/update_site_travis.bash
@@ -33,14 +33,15 @@ git config user.email "travis@travis-ci.org"
 
 GH_REPO_REF="github.com/${DOCS_REPO_OWNER}/${DOCS_REPO_NAME}.git"
 
-# Assume the book has already been built, and was moved to `build/`
+# Assume the book has already been built, and was moved to `_book/`
 # inside the same directory as this script.
+book_build_dir=_book
 
-if [ -d build ]; then
+if [ -d "${book_build_dir}" ]; then
     echo "${bold}Cloning the website repo...${normal}"
     git clone -b "${DOCS_BRANCH_NAME}" https://git@"${GH_REPO_REF}"
     rm -rf ./"${DOCS_REPO_NAME}"/*
-    cp -a ./build/* ./"${DOCS_REPO_NAME}"
+    cp -a ./"${book_build_dir}"/* ./"${DOCS_REPO_NAME}"
     pushd ./"${DOCS_REPO_NAME}"
     echo "www.algorithm-archive.org" > CNAME
     echo "${bold}Adding changes...${normal}"


### PR DESCRIPTION
The build in https://travis-ci.org/github/algorithm-archivists/algorithm-archive/builds/706151796 from https://github.com/algorithm-archivists/algorithm-archive/pull/720 exploded because the build directory changed from `build` to `_book` and I failed to review the code that wasn't changed. See https://github.com/algorithm-archivists/algorithm-archivists.github.io/tree/b27e0192c076a74f7a53915ae9233545061a6cb5 for effect.