### PR TITLE
Huffman encoding in Coconut

### DIFF
--- a/contents/huffman_encoding/code/coconut/huffman.coco
+++ b/contents/huffman_encoding/code/coconut/huffman.coco
@@ -49,33 +49,6 @@ def build_huffman_tree(message):
 
     return trees[0]
 
-# constructs the mapping with recursion
-"""def build_codebook(tree, code=''):
-
-    frequencies = Counter(message)
-    trees = frequencies.most_common()
-
-    # while there is more than one tree
-    while len(trees) > 1:
-
-        # pop off the two trees of least weight from the trees list
-        tree_left,weight_left = trees.pop()
-        tree_right,weight_right = trees.pop()
-
-        # combine the nodes and add back to the nodes list
-        new_tree = [tree_left, tree_right]
-        new_weight = weight_left + weight_right
-
-        # find the first tree that has a weight smaller than new_weight and returns its index in the list
-        # If no such tree can be found, use len(trees) instead to append
-        index = next((i for i, tree in enumerate(trees) if tree[1] < new_weight), len(trees))
-
-        # insert the new tree there
-        trees.insert(index, (new_tree, new_weight))
-
-    huffman_tree = trees[0][0]
-    return huffman_tree"""
-
 def build_codebook(Empty(), code='') = []
 addpattern def build_codebook(Leaf(char, n), code='') = [(char, code)]
 addpattern def build_codebook(Node(left, right), code='') = build_codebook(left, code+'0') + build_codebook(right, code+'1')
@@ -83,21 +56,15 @@ addpattern def build_codebook(Node(left, right), code='') = build_codebook(left,
 # encodes the message
 def huffman_encode(codebook, message):
 
-    encoded_message = ''
-
     # build a char -> code dictionary
     forward_dict = dict(codebook)
 
-    # replace each character with its code
-    for char in message:
-        encoded_message += forward_dict[char]
-
-    return encoded_message
+    return ''.join(message |> map$(forward_dict[]))
 
 # decodes a message
 def huffman_decode(codebook, encoded_message):
 
-    decoded_message = ''
+    decoded_message = []
     key = ''
 
     # build a code -> char dictionary
@@ -107,13 +74,13 @@ def huffman_decode(codebook, encoded_message):
     # if the bit is in the dictionary, replace the bit with the paired character
     # else look at the bit and the following bits together until a match occurs
     # move to the next bit not yet looked at
-    for index, bit in enumerate(encoded_message):
+    for bit in encoded_message:
         key += bit
         if key in inverse_dict:
-            decoded_message += inverse_dict[key]
+            decoded_message.append(inverse_dict[key])
             key = ''
 
-    return decoded_message
+    return ''.join(decoded_message)
 
 
 if __name__ == '__main__':
@@ -121,14 +88,14 @@ if __name__ == '__main__':
     message = 'bibbity_bobbity'
     tree = build_huffman_tree(message)
     codebook = build_codebook(tree)
-    #encoded_message = huffman_encode(codebook, message)
-    #decoded_message = huffman_decode(codebook, encoded_message)
+    encoded_message = huffman_encode(codebook, message)
+    decoded_message = huffman_decode(codebook, encoded_message)
 
     print('message:', message)
     print('huffman tree:', tree)
     print('codebook:', codebook)
-    #print('encoded message: ' + encoded_message)
-    #print('decoded message: ' + decoded_message)
+    print('encoded message:', encoded_message)
+    print('decoded message: ' + decoded_message)
 
     # prints the following:
     #

--- a/contents/huffman_encoding/code/coconut/huffman.coco
+++ b/contents/huffman_encoding/code/coconut/huffman.coco
@@ -1,0 +1,142 @@
+# Huffman Encoding
+# Python 2.7+
+# Submitted by Matthew Giallourakis
+
+from collections import Counter, deque
+from bisect import bisect, bisect_left
+
+class Tree
+
+data Empty() from Tree
+data Leaf(char, n is int) from Tree:
+    def __str__(self):
+        return f'Leaf({self.char}, {self.n})'
+
+    __repr__ = __str__
+
+data Node(left is Tree, right is Tree) from Tree:
+    def __str__(self):
+        return f'Node({str(self.left)}, {str(self.right)})'
+    __repr__ = __str__
+
+def weight(Tree()) = 0
+addpattern def weight(Leaf(char, n)) = n
+addpattern def weight(Node(left, right)) = weight(left) + weight(right)
+
+# constructs the tree
+def build_huffman_tree(message):
+
+    # get sorted list of character and frequency pairs
+    frequencies = Counter(message)
+    trees = frequencies.most_common() |> map$(t -> Leaf(*t)) |> reversed |> list
+
+    # while there is more than one tree
+    while len(trees) > 1:
+        print(trees)
+
+        # pop off the two trees of least weight from the trees list
+        tree_left = trees.pop()
+        tree_right = trees.pop()
+
+        # combine the nodes and add back to the nodes list
+        new_tree = Node(tree_left, tree_right)
+
+        # find the first tree that has a weight smaller than new_weight and returns its index in the list
+        # If no such tree can be found, use len(trees) instead to append
+        index = bisect(trees |> map$(weight) |> list, weight(new_tree))
+
+        # insert the new tree there
+        trees.insert(index, new_tree)
+
+    huffman_tree = trees[0]
+    return huffman_tree
+
+# constructs the mapping with recursion
+"""def build_codebook(tree, code=''):
+
+    frequencies = Counter(message)
+    trees = frequencies.most_common()
+
+    # while there is more than one tree
+    while len(trees) > 1:
+
+        # pop off the two trees of least weight from the trees list
+        tree_left,weight_left = trees.pop()
+        tree_right,weight_right = trees.pop()
+
+        # combine the nodes and add back to the nodes list
+        new_tree = [tree_left, tree_right]
+        new_weight = weight_left + weight_right
+
+        # find the first tree that has a weight smaller than new_weight and returns its index in the list
+        # If no such tree can be found, use len(trees) instead to append
+        index = next((i for i, tree in enumerate(trees) if tree[1] < new_weight), len(trees))
+
+        # insert the new tree there
+        trees.insert(index, (new_tree, new_weight))
+
+    huffman_tree = trees[0][0]
+    return huffman_tree"""
+
+def build_codebook(Empty(), code='') = []
+addpattern def build_codebook(Leaf(char, n), code='') = [(char, code)]
+addpattern def build_codebook(Node(left, right), code='') = build_codebook(left, code+'0') + build_codebook(right, code+'1')
+
+# encodes the message
+def huffman_encode(codebook, message):
+
+    encoded_message = ''
+
+    # build a char -> code dictionary
+    forward_dict = dict(codebook)
+
+    # replace each character with its code
+    for char in message:
+        encoded_message += forward_dict[char]
+
+    return encoded_message
+
+# decodes a message
+def huffman_decode(codebook, encoded_message):
+
+    decoded_message = ''
+    key = ''
+
+    # build a code -> char dictionary
+    inverse_dict = dict([(v, k) for k, v in codebook])
+
+    # for each bit in the encoding
+    # if the bit is in the dictionary, replace the bit with the paired character
+    # else look at the bit and the following bits together until a match occurs
+    # move to the next bit not yet looked at
+    for index, bit in enumerate(encoded_message):
+        key += bit
+        if key in inverse_dict:
+            decoded_message += inverse_dict[key]
+            key = ''
+
+    return decoded_message
+
+
+if __name__ == '__main__':
+    # test example
+    message = 'bibbity_bobbity'
+    tree = build_huffman_tree(message)
+    codebook = build_codebook(tree)
+    #encoded_message = huffman_encode(codebook, message)
+    #decoded_message = huffman_decode(codebook, encoded_message)
+
+    print('message: ' + message)
+    print('huffman tree: ' + str(tree))
+    print('codebook: ' + str(codebook))
+    #print('encoded message: ' + encoded_message)
+    #print('decoded message: ' + decoded_message)
+
+    # prints the following:
+    #
+    #  message: bibbity_bobbity
+    #  huffman_tree: ['b', [[['_', 'o'], 'y'], ['t', 'i']]]
+    #  codebook: [('b', '0'), ('_', '1000'), ('o', '1001'),
+    #             ('y', '101'), ('t', '110'), ('i', '111')]
+    #  encoded_message: 01110011111010110000100100111110101
+    #  decoded_message: bibbity_bobbity

--- a/contents/huffman_encoding/code/coconut/huffman.coco
+++ b/contents/huffman_encoding/code/coconut/huffman.coco
@@ -3,8 +3,7 @@
 # Submitted by Matthew Giallourakis
 
 from collections import Counter, deque
-from bisect import bisect, bisect_left
-
+from bisect import bisect
 class Tree
 
 data Empty() from Tree
@@ -100,8 +99,9 @@ if __name__ == '__main__':
     # prints the following:
     #
     #  message: bibbity_bobbity
-    #  huffman_tree: ['b', [[['_', 'o'], 'y'], ['t', 'i']]]
-    #  codebook: [('b', '0'), ('_', '1000'), ('o', '1001'),
-    #             ('y', '101'), ('t', '110'), ('i', '111')]
-    #  encoded_message: 01110011111010110000100100111110101
+    #  huffman_tree: Node(Leaf(b, 6), Node(Node(Leaf(y, 2), Leaf(t, 2)), Node(Node(Leaf(o, 1), Leaf(_, 1)), Leaf(i, 3))))
+
+    #  codebook: [('b', '0'), ('y', '100'), ('t', '101'),
+    #             ('o', '1100'), ('_', '1101'), ('i', '111')]
+    #  encoded_message: 01110011110110011010110000111101100
     #  decoded_message: bibbity_bobbity

--- a/contents/huffman_encoding/code/coconut/huffman.coco
+++ b/contents/huffman_encoding/code/coconut/huffman.coco
@@ -9,15 +9,15 @@ class Tree
 
 data Empty() from Tree
 data Leaf(char, n is int) from Tree:
-    def __str__(self):
+    def __repr__(self):
         return f'Leaf({self.char}, {self.n})'
 
-    __repr__ = __str__
+    __str__ = __repr__
 
 data Node(left is Tree, right is Tree) from Tree:
-    def __str__(self):
+    def __repr__(self):
         return f'Node({str(self.left)}, {str(self.right)})'
-    __repr__ = __str__
+    __str__ = __repr__
 
 def weight(Tree()) = 0
 addpattern def weight(Leaf(char, n)) = n
@@ -28,7 +28,7 @@ def build_huffman_tree(message):
 
     # get sorted list of character and frequency pairs
     frequencies = Counter(message)
-    trees = frequencies.most_common() |> map$(t -> Leaf(*t)) |> reversed |> list
+    trees = frequencies.most_common() |> map$(t -> Leaf(*t)) |> list
 
     # while there is more than one tree
     while len(trees) > 1:
@@ -43,7 +43,7 @@ def build_huffman_tree(message):
 
         # find the first tree that has a weight smaller than new_weight and returns its index in the list
         # If no such tree can be found, use len(trees) instead to append
-        index = bisect(trees |> map$(weight) |> list, weight(new_tree))
+        index = bisect_left(trees |> map$(weight) |> list, weight(new_tree))
 
         # insert the new tree there
         trees.insert(index, new_tree)

--- a/contents/huffman_encoding/code/coconut/huffman.coco
+++ b/contents/huffman_encoding/code/coconut/huffman.coco
@@ -1,6 +1,7 @@
 # Huffman Encoding
-# Python 2.7+
-# Submitted by Matthew Giallourakis
+# Coconut
+# Submitted by Amaras
+# Inspired by Matthew Giallourakis
 
 from collections import Counter, deque
 from bisect import bisect

--- a/contents/huffman_encoding/code/coconut/huffman.coco
+++ b/contents/huffman_encoding/code/coconut/huffman.coco
@@ -28,28 +28,26 @@ def build_huffman_tree(message):
 
     # get sorted list of character and frequency pairs
     frequencies = Counter(message)
-    trees = frequencies.most_common() |> map$(t -> Leaf(*t)) |> list
+    trees = frequencies.most_common() |> map$(t -> Leaf(*t)) |> reversed |> deque
 
     # while there is more than one tree
     while len(trees) > 1:
-        print(trees)
 
         # pop off the two trees of least weight from the trees list
-        tree_left = trees.pop()
-        tree_right = trees.pop()
+        tree_left = trees.popleft()
+        tree_right = trees.popleft()
 
         # combine the nodes and add back to the nodes list
         new_tree = Node(tree_left, tree_right)
 
         # find the first tree that has a weight smaller than new_weight and returns its index in the list
         # If no such tree can be found, use len(trees) instead to append
-        index = bisect_left(trees |> map$(weight) |> list, weight(new_tree))
+        index = bisect(trees |> map$(weight) |> list, weight(new_tree))
 
         # insert the new tree there
         trees.insert(index, new_tree)
 
-    huffman_tree = trees[0]
-    return huffman_tree
+    return trees[0]
 
 # constructs the mapping with recursion
 """def build_codebook(tree, code=''):
@@ -126,9 +124,9 @@ if __name__ == '__main__':
     #encoded_message = huffman_encode(codebook, message)
     #decoded_message = huffman_decode(codebook, encoded_message)
 
-    print('message: ' + message)
-    print('huffman tree: ' + str(tree))
-    print('codebook: ' + str(codebook))
+    print('message:', message)
+    print('huffman tree:', tree)
+    print('codebook:', codebook)
     #print('encoded message: ' + encoded_message)
     #print('decoded message: ' + decoded_message)
 

--- a/contents/huffman_encoding/huffman_encoding.md
+++ b/contents/huffman_encoding/huffman_encoding.md
@@ -93,6 +93,8 @@ Whether you use a stack or straight-up recursion also depends on the language, b
 [import, lang:"asm-x64"](code/asm-x64/huffman.s)
 {% sample lang="scala" %}
 [import, lang:"scala"](code/scala/huffman_encoding.scala)
+{% sample lang="coco" %}
+[import, lang:"coconut"](code/coconut/huffman.coco)
 {% endmethod %}
 
 <script>


### PR DESCRIPTION
This is a first draft of what the Huffman encoding would look like in Coconut.

Sadly, I haven't been able to build the tree correctly yet, so the codebook isn't correct, but it seems to be correct from the tree given.

So the output for now (barring the debug `print` statements) is:
```
message: bibbity_bobbity
huffman tree: Node(Node(Node(Leaf(i, 3), Leaf(b, 6)), Node(Leaf(y, 2), Leaf(t, 2))), Node(Leaf(o, 1), Leaf(_, 1)))
codebook: [('i', '000'), ('b', '001'), ('y', '010'), ('t', '011'), ('o', '10'), ('_', '11')]
```
However, the code says that the output should be:
```
message: bibbity_bobbity
huffman_tree: ['b', [[['_', 'o'], 'y'], ['t', 'i']]]
codebook: [('b', '0'), ('_', '1000'), ('o', '1001'), ('y', '101'), ('t', '110'), ('i', '111')]
```
I don't see my mistake yet, so I'll leave this PR as a draft for now