### PR TITLE
Forward Euler method in Coconut

### DIFF
--- a/contents/forward_euler_method/code/coconut/euler.coco
+++ b/contents/forward_euler_method/code/coconut/euler.coco
@@ -22,6 +22,6 @@ if __name__ == '__main__':
     n = 100
     threshold = 0.01
 
-    result = list(forward_euler(time_step, n))
+    result = forward_euler(time_step, n)
     approx = check(result, threshold, time_step)
     print("All values within threshold") if approx else print("Value(s) not in threshold")

--- a/contents/forward_euler_method/code/coconut/euler.coco
+++ b/contents/forward_euler_method/code/coconut/euler.coco
@@ -1,4 +1,4 @@
-import numpy as np
+import math
 
 def forward_euler(time_step, n):
     y = 1
@@ -8,9 +8,13 @@ def forward_euler(time_step, n):
 
 
 def check(result, threshold, time_step):
-    x = np.linspace(0, 1, 1 / time_step)
-    solution = np.exp(-3 * x)
-    return np.abs(solution - result) <= threshold).all()
+    approx = True
+    for i, y in enumerate(result):
+        solution = math.exp(-3 * i * time_step)
+        if not math.isclose(y, solution, abs_tol=threshold):
+            print(y, solution)
+            approx = False
+    return approx
 
 
 if __name__ == '__main__':
@@ -18,6 +22,6 @@ if __name__ == '__main__':
     n = 100
     threshold = 0.01
 
-    result = np.array(list(forward_euler(time_step, n)))
+    result = list(forward_euler(time_step, n))
     approx = check(result, threshold, time_step)
     print("All values within threshold") if approx else print("Value(s) not in threshold")

--- a/contents/forward_euler_method/code/coconut/euler.coco
+++ b/contents/forward_euler_method/code/coconut/euler.coco
@@ -1,0 +1,23 @@
+import numpy as np
+
+def forward_euler(time_step, n):
+    y = 1
+    for _ in range(n):
+        yield y
+        y *= (1 - 3 * time_step)
+
+
+def check(result, threshold, time_step):
+    x = np.linspace(0, 1, 1 / time_step)
+    solution = np.exp(-3 * x)
+    return np.abs(solution - result) <= threshold).all()
+
+
+if __name__ == '__main__':
+    time_step = 0.01
+    n = 100
+    threshold = 0.01
+
+    result = np.array(list(forward_euler(time_step, n)))
+    approx = check(result, threshold, time_step)
+    print("All values within threshold") if approx else print("Value(s) not in threshold")

--- a/contents/forward_euler_method/code/coconut/euler.coco
+++ b/contents/forward_euler_method/code/coconut/euler.coco
@@ -1,18 +1,19 @@
 import math
 
 def forward_euler(time_step, n):
-    y = 1
-    for _ in range(n):
-        yield y
-        y *= (1 - 3 * time_step)
+    factors = [1] + [1 - 3 * time_step] * (n-1)
+    # We want all the cumulative values, thus the use of scan
+    return scan((*), factors)
+
 
 
 def check(result, threshold, time_step):
     approx = True
-    for i, y in enumerate(result):
-        solution = math.exp(-3 * i * time_step)
-        if not math.isclose(y, solution, abs_tol=threshold):
-            print(y, solution)
+    # A scan object has a len if the underlying iterable has a len
+    solution = range(len(result)) |> map$(i -> math.exp(-3*i*time_step))
+    for y, sol in zip(result, solution):
+        if not math.isclose(y, sol, abs_tol=threshold):
+            print(y, sol)
             approx = False
     return approx
 

--- a/contents/forward_euler_method/forward_euler_method.md
+++ b/contents/forward_euler_method/forward_euler_method.md
@@ -146,6 +146,8 @@ Full code for the visualization follows:
 [import, lang:"nim"](code/nim/forwardeuler.nim)
 {% sample lang="lisp" %}
 [import, lang="lisp"](code/clisp/euler.lisp)
+{%sample lang="coco" %}
+[import, lang:"coconut"](code/coconut/euler.coco)
 {% endmethod %}
 
 <script>


### PR DESCRIPTION
Okay, so the commits show two possible versions of the Forward Euler method in Coconut.
Before editing the md file, I want to have some feedback on that.
I'm not sure I can have something more functional style than that, but it could be.

If there's no way, which version do you prefer? V1 is more concise and efficient for checking, but might be more confusing to beginners. V2 could maybe be made a little bit more functional style, and doesn't need creating a list or an array.