### PR TITLE
Make Bogosort in Nim more idiomatic

### DIFF
--- a/contents/bogo_sort/code/nim/bogo_sort.nim
+++ b/contents/bogo_sort/code/nim/bogo_sort.nim
@@ -3,24 +3,23 @@ import random
 randomize()
 
 proc print_array(a: openArray[int]) =
-    for n in 0 .. len(a)-1:
-        echo a[n]
+  for n in 0 .. len(a)-1:
+    echo a[n]
 
-proc is_sorted(a: openArray[int]): bool =
-    for n in 1 .. len(a)-1:
-        if a[n] > a[n-1]:
-            return false
-    
-    return true
+func is_sorted(a: openArray[int]): bool =
+  result = true
+  for n in 1 .. len(a)-1:
+    if a[n] > a[n-1]:
+      result = false
+      break
 
 proc bogo_sort(a: var openArray[int]) =
-    while not is_sorted(a):
-        shuffle(a)
-        
+  while not is_sorted(a):
+    shuffle(a)
 
-var x: array[10,int] =  [32,32,64,16,128,8,256,4,512,2]
-
-print_array(x)
-bogo_sort(x)
-echo "\n"
-print_array(x)
+when isMainModule:
+  var x = [32, 32, 64, 16, 128, 8, 256, 4, 512, 2]
+  print_array(x)
+  bogo_sort(x)
+  echo "\n"
+  print_array(x)


### PR DESCRIPTION
- `func` signifies that the procedures have no side effects: they are proper functions.
- Fix indentation to be 2 spaces instead of 4.
- Use the implicit `result` return variable instead of explicit returns.
- `when isMainModule` behaves the same way as `if __name__ == "__main__"` in Python.