### PR TITLE
Make Euclid's algorithm in Nim more idiomatic

### DIFF
--- a/contents/euclidean_algorithm/code/nim/euclid_algorithm.nim
+++ b/contents/euclidean_algorithm/code/nim/euclid_algorithm.nim
@@ -1,16 +1,16 @@
-proc euclid_mod(in1, in2: int): int =
+func euclid_mod(in1, in2: int): int =
   var
     a = abs(in1)
     b = abs(in2)
-    
+
   while b != 0:
     let temp: int = b
     b = a mod b
     a = temp;
 
-    return a
+  result = a
 
-proc euclid_sub(in1, in2: int): int =
+func euclid_sub(in1, in2: int): int =
   var
     a = abs(in1)
     b = abs(in2)
@@ -20,8 +20,9 @@ proc euclid_sub(in1, in2: int): int =
       a -= b
     else:
       b -= a
-    
-    return a
 
-echo euclid_sub(64 * 67, 64 * 81)
-echo euclid_mod(128 * 12, 128 * 77)
+  result = a
+
+when isMainModule:
+  echo euclid_sub(64 * 67, 64 * 81)
+  echo euclid_mod(128 * 12, 128 * 77)


### PR DESCRIPTION
- `func` signifies that the procedures have no side effects: they are proper functions.
- Use the implicit `result` return variable instead of explicit returns.
- `when isMainModule` behaves the same way as `if __name__ == "__main__"` in Python.
