### PR TITLE
julia bubble sort suggestions

### DIFF
--- a/contents/bubble_sort/code/julia/bubble.jl
+++ b/contents/bubble_sort/code/julia/bubble.jl
@@ -1,19 +1,24 @@
-function bubble_sort!(a::Vector{Float64})
-    n = length(a)
-    for i = 1:n
-        for j = 1:n-1
-            if(a[j] < a[j+1])
+using Base: copymutable
+
+function bubble_sort!(a::AbstractVector)
+    ax     = axes(a, 1)
+    n      = length(ax)
+    lo, hi = first(ax), last(ax)
+
+    for _ in lo:hi
+        @inbounds for j in lo:hi-1
+            if a[j] < a[j+1]
                 a[j], a[j+1] = a[j+1], a[j]
             end
         end
     end
+
+    return a
 end
 
+bubble_sort(a) =  bubble_sort!(copymutable(a))
 
-function main()
-    a = [1., 3, 2, 4, 5, 10, 50, 7, 1.5, 0.3]
+let a = rand(1:100, 9)
     bubble_sort!(a)
-    println(a)
+    display(a)
 end
-
-main()

--- a/contents/bubble_sort/code/julia/bubble.jl
+++ b/contents/bubble_sort/code/julia/bubble.jl
@@ -1,12 +1,10 @@
 using Base: copymutable
 
 function bubble_sort!(a::AbstractVector)
-    ax     = axes(a, 1)
-    n      = length(ax)
-    lo, hi = first(ax), last(ax)
+    n = length(a)
 
-    for _ in lo:hi
-        @inbounds for j in lo:hi-1
+    for _ in 1:n
+        @inbounds for j in 1:n-1
             if a[j] < a[j+1]
                 a[j], a[j+1] = a[j+1], a[j]
             end
@@ -18,7 +16,7 @@ end
 
 bubble_sort(a) =  bubble_sort!(copymutable(a))
 
-let a = rand(1:100, 9)
+let a = [1, 9, 2, 8, 3, 7, 4, 6, 5]
     bubble_sort!(a)
     display(a)
 end


### PR DESCRIPTION
- Restrict type less. `bubble_sort` should be able to sort any `AbstractVector`.
- Generalised to arbitrary indexing offset so that any offset vector can be sorted.
- Use `_` as a placeholder variable.
- Add `@inbounds` for better performance.
- Have mutating version return its result.
- Add `bubble_sort`, a non-mutating version.
- Use `let` keyword rather than `main` function.
- Replace `[1., 3, 2, 4, 5, 10, 50, 7, 1.5, 0.3]` (`Vector{Any}`) with `rand(1:100, 9)` (`Vector{Int}`).