### PR TITLE
Fix github profile link in the affine transformations chapter

### DIFF
--- a/contents/affine_transformations/affine_transformations.md
+++ b/contents/affine_transformations/affine_transformations.md
@@ -312,7 +312,7 @@ The code examples are licensed under the MIT license (found in [LICENSE.md](http
 
 ##### Text
 
-The text of this chapter was written by [James Schloss](https://github.com/leio) and is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/legalcode).
+The text of this chapter was written by [James Schloss](https://github.com/leios) and is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/legalcode).
 
 [<p><img  class="center" src="../cc/CC-BY-SA_icon.svg" /></p>](https://creativecommons.org/licenses/by-sa/4.0/)
 


### PR DESCRIPTION
Fixed the github link at the end of the affine transformations chapter