### PR TITLE
changing title of Algorithm Archive.

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,6 +1,7 @@
 {
   "honkit": ">= 3.0.0",
   "root": "./",
+  "title": "Arcane Algorithm Archive",
   "plugins": [
     "mathjax@https://github.com/algorithm-archivists/plugin-mathjax",
     "bibtex-cite",


### PR DESCRIPTION
This means that each website will say "Arcane Algorithm Archive" instead of "Honkit"

Apparently it takes me a while to actually RT(F)M