### PR TITLE
Fix typos in IFS/julia and IFS/c

### DIFF
--- a/contents/IFS/code/c/IFS.c
+++ b/contents/IFS/code/c/IFS.c
@@ -36,7 +36,7 @@ int main() {
 
     chaos_game(shape_points, 3, out_points, 1000);
 
-    FILE *fp = fopen("out.dat", "w+");
+    FILE *fp = fopen("sierpinksi.dat", "w+");
 
     for (int i = 0; i < 1000; ++i) {
         fprintf(fp, "%f\t%f\n", out_points[i].x, out_points[i].y);

--- a/contents/IFS/code/julia/IFS.jl
+++ b/contents/IFS/code/julia/IFS.jl
@@ -26,4 +26,4 @@ shape_points = [[0.0, 0.0],
                 [0.5, sqrt(0.75)],
                 [1.0, 0.0]]
 output_points = chaos_game(10000, shape_points)
-writedlm("out.dat", output_points)
+writedlm("sierpinski.dat", output_points)


### PR DESCRIPTION
There were some inconsistencies in the naming scheme of the output files.
Now all implementations output into `sierpinski.dat` instead of `out.dat`.