### PR TITLE
Add support for github action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: build
+on: pull_request
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install and build
+        run: |
+          npm install
+          npx honkit build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ntindle/algorithm-archive'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install and build
+        run: |
+          npm install
+          npx honkit build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: _book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.repository == 'ntindle/algorithm-archive'
+    if: github.repository == 'algorithm-archivists/algorithm-archive'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,3 +55,4 @@ This file lists everyone, who contributed to this repo and wanted to show up her
 - Jonathan Dönszelmann
 - Ishaan Verma
 - Delphi1024
+- ntindle


### PR DESCRIPTION
Hello, this will require minor configuration in the repo settings.

Please read the full text, and references below before merging.

1. Merge the PR
1. You will need to go to `Settings` -> `Pages` -> `Source` -> `Branch`: Select `gh-pages`, `Folder`: Select `/(root)`
1. Hit `Save`
1.  This will deploy a version to [algorithm-archivists.github.io/algorithm-archive](algorithm-archivists.github.io/algorithm-archive)
1. If you do not see it here, wait 3-8 minutes.

Up to here, this is non destructive to the current deployment mechanisms.

<strong>You can stop here with no side effects to any services. I highly recommend taking a break here and letting github dns propagate</strong>


<b>The next change will bring down the site if it is incorrect.</b>

> Note: if you are hosting anything else on this domain, do not follow these steps. Comment on the PR and let me know and I will help with the config

1. Read [this](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) doc in full
1. Follow the steps listed [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain-and-the-www-subdomain-variant)
1. Configure the custom domains. My DNS records for [tindle.dev](http://tindle.dev) look like the following
![image](https://user-images.githubusercontent.com/8845353/128969507-7ce515d9-cd8b-4d01-8b26-7a7a396908f2.png)
1. Add the custom domain to GitHub Pages in `Settings` -> `Pages` -> `Custom Domain` -> Fill out the custom domain with `algorithm-archive.org` 
My GitHub Pages settings looks like this:

![image](https://user-images.githubusercontent.com/8845353/129050606-1351a7e9-b2b4-4a46-9863-ba26cb7f6777.png)