### PR TITLE
rename task to just build from build and deploy from GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on: pull_request
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
UI naming fix. Doesn't affect anything but the name that's reported in the PR