### PR TITLE
Verlet Integration: Output standardization

### DIFF
--- a/contents/verlet_integration/code/asm-x64/verlet.s
+++ b/contents/verlet_integration/code/asm-x64/verlet.s
@@ -4,9 +4,9 @@
   zero:          .double 0.0
   two:           .double 2.0
   half:          .double 0.5
-  verlet_fmt:    .string "Time for Verlet integration is: %lf\n"
-  stormer_fmt:   .string "Time and Velocity for Stormer Verlet Integration is: %lf, %lf\n"
-  velocity_fmt:  .string "Time and Velocity for Velocity Verlet Integration is: %lf, %lf\n"
+  verlet_fmt:    .string "[#] Time for Verlet integration is:\n%lf\n"
+  stormer_fmt:   .string "[#] Time for Stormer Verlet Integration is:\n%lf\n[#] Velocity for Stormer Verlet Integration is:\n%lf\n"
+  velocity_fmt:  .string "[#] Time for Velocity Verlet Integration is:\n%lf\n[#] Velocity for Velocity Verlet Integration is:\n%lf\n"
   pos:           .double 5.0
   acc:           .double -10.0
   dt:            .double 0.01

--- a/contents/verlet_integration/code/c++/verlet.cpp
+++ b/contents/verlet_integration/code/c++/verlet.cpp
@@ -64,19 +64,19 @@ int main() {
   // each of these functions.
 
   double time = verlet(5.0, -10, 0.01);
-  std::cout << "Time for Verlet integration is: " \
+  std::cout << "[#] Time for Verlet integration is:\n" \
             << time << std::endl;
 
   timestep timestep_sv = stormer_verlet(5.0, -10, 0.01);
-  std::cout << "Time for Stormer Verlet integration is: " \
+  std::cout << "[#] Time for Stormer Verlet integration is:\n" \
             << timestep_sv.time << std::endl;
-  std::cout << "Velocity for Stormer Verlet integration is: " \
+  std::cout << "[#] Velocity for Stormer Verlet integration is:\n" \
             << timestep_sv.vel << std::endl;
 
   timestep timestep_vv = velocity_verlet(5.0, -10, 0.01);
-  std::cout << "Time for velocity Verlet integration is: " \
+  std::cout << "[#] Time for velocity Verlet integration is:\n" \
             << timestep_vv.time << std::endl;
-  std::cout << "Velocity for velocity Verlet integration is: " \
+  std::cout << "[#] Velocity for velocity Verlet integration is:\n" \
             << timestep_vv.vel << std::endl;
 
   return 0;

--- a/contents/verlet_integration/code/c/verlet.c
+++ b/contents/verlet_integration/code/c/verlet.c
@@ -46,16 +46,20 @@ int main() {
     double time, vel;
 
     verlet(&time, 5.0, -10, 0.01);
-    printf("Time for Verlet integration is: %lf\n",
-           time);
+    printf("[#] Time for Verlet integration is:\n");
+    printf("%lf\n", time);
 
     stormer_verlet(&time, &vel, 5.0, -10, 0.01);
-    printf("Time and velocity for Stormer Verlet integration is: %lf, %lf\n",
-           time, vel);
+    printf("[#] Time for Stormer Verlet integration is:\n");
+    printf("%lf\n", time);
+    printf("[#] Velocity for Stormer Verlet integration is:\n");
+    printf("%lf\n", vel);
 
     velocity_verlet(&time, &vel, 5.0, -10, 0.01);
-    printf("Time and velocity for velocity Verlet integration is: %lf, %lf\n",
-           time, vel);
+    printf("[#] Time for velocity Verlet integration is:\n");
+    printf("%lf\n", time);
+    printf("[#] Velocity for Stormer Verlet integration is:\n");
+    printf("%lf\n", vel);
 
     return 0;
 }

--- a/contents/verlet_integration/code/clisp/verlet.lisp
+++ b/contents/verlet_integration/code/clisp/verlet.lisp
@@ -34,12 +34,17 @@
     while (> p 0)
     finally (return (list time vel))))
 
-(format T "Time for Verlet integration: ~d~%" (verlet 5 -10 0.01))
+(format T "[#] Time for Verlet integration:~%")
+(format T "~d~%" (verlet 5 -10 0.01))
 
 (defvar stormer-verlet-result (stormer-verlet 5 -10 0.01))
-(format T "Time for Stormer Verlet integration is: ~d~%" (first stormer-verlet-result))
-(format T "Velocity for Stormer Verlet integration is: ~d~%" (second stormer-verlet-result))
+(format T "[#] Time for Stormer Verlet integration is:~%")
+(format T "~d~%" (first stormer-verlet-result))
+(format T "[#] Velocity for Stormer Verlet integration is:~%")
+(format T "~d~%" (second stormer-verlet-result))
 
 (defvar velocity-verlet-result (velocity-verlet 5 -10 0.01))
-(format T "Time for velocity Verlet integration is: ~d~%" (first velocity-verlet-result))
-(format T "Velocity for velocity Verlet integration is: ~d~%" (second velocity-verlet-result))
+(format T "[#] Time for velocity Verlet integration is:~%")
+(format T "~d~%" (first velocity-verlet-result))
+(format T "[#] Velocity for velocity Verlet integration is:~%")
+(format T "~d~%" (second velocity-verlet-result))

--- a/contents/verlet_integration/code/fortran/verlet.f90
+++ b/contents/verlet_integration/code/fortran/verlet.f90
@@ -91,18 +91,27 @@ PROGRAM verlet_integration
     ! Verlet 
     CALL verlet(pos, acc, dt, time)
     
-    WRITE(*,*) 'Time for Verlet integration: ', time 
+    WRITE(*,*) '[#] Time for Verlet integration:'
+    WRITE(*,*) time 
     
     ! stormer Verlet 
     pos = 5d0
     CALL stormer_verlet(pos, acc, dt, time, vel)
     
-    WRITE(*,*) 'Time for Stormer-Verlet integration: ', time 
+    WRITE(*,*) '[#] Time for Stormer Verlet integration:'
+    WRITE(*,*) time
+    WRITE(*,*) '[#] Velocity for Stormer Verlet integration:'
+    WRITE(*,*) vel
+    
+    
     
     ! Velocity Verlet
     pos = 5d0
     CALL velocity_verlet(pos, acc, dt, time, vel)
     
-    WRITE(*,*) 'Time for Velocity-Verlet integration: ', time 
-    
+    WRITE(*,*) '[#] Time for velocity Verlet integration:'
+    WRITE(*,*) time
+    WRITE(*,*) '[#] Velocity for velocity Verlet integration:'
+    WRITE(*,*) vel
+
 END PROGRAM verlet_integration

--- a/contents/verlet_integration/code/golang/verlet.go
+++ b/contents/verlet_integration/code/golang/verlet.go
@@ -43,18 +43,18 @@ func velocityVerlet(pos, acc, dt float64) (time, vel float64) {
 
 func main() {
 	time := verlet(5., -10., .01)
-	fmt.Println("Verlet")
-	fmt.Println("Time:", time)
-	fmt.Println()
+	fmt.Println("[#] Time for Verlet integration is:")
+	fmt.Println(time)
 
 	time, vel := stormerVerlet(5., -10., .01)
-	fmt.Println("Stormer-Verlet")
-	fmt.Println("Time:", time)
-	fmt.Println("Velocity:", vel)
-	fmt.Println()
-
+	fmt.Println("[#] Time for Stormer Verlet integration is:")
+	fmt.Println(time)
+	fmt.Println("[#] Velocity for Stormer Verlet integration is:")
+	fmt.Println(vel)
+	
 	time, vel = velocityVerlet(5., -10., .01)
-	fmt.Println("Velocity Verlet")
-	fmt.Println("Time:", time)
-	fmt.Println("Velocity:", vel)
+	fmt.Println("[#] Time for velocity Verlet integration is:")
+	fmt.Println(time)
+	fmt.Println("[#] Velocity for velocity Verlet integration is:")
+	fmt.Println(vel)
 }

--- a/contents/verlet_integration/code/haskell/verlet.hs
+++ b/contents/verlet_integration/code/haskell/verlet.hs
@@ -48,7 +48,17 @@ main = do
       dt = 0.001
       freefall _ = -10
       aboveGround (x, _, _, _) = x > 0
-      integrate m = last $ takeWhile aboveGround $ trajectory m freefall dt p0
-  print $ integrate verlet
-  print $ integrate stormerVerlet
-  print $ integrate velocityVerlet
+      timeVelocity m =
+        let (_, v, _, t) = last $ takeWhile aboveGround $ trajectory m freefall dt p0
+         in (show t, show v)
+
+  print "[#] Time for Verlet integration is:"
+  print $ fst $ timeVelocity verlet
+  print "[#] Time for Stormer Verlet integration is:"
+  print $ fst $ timeVelocity stormerVerlet
+  print "[#] Velocity for Stormer Verlet integration is:"
+  print $ snd $ timeVelocity stormerVerlet
+  print "[#] Time for velocity Verlet integration is:"
+  print $ fst $ timeVelocity velocityVerlet
+  print "[#] Velocity for velocity Verlet integration is:"
+  print $ snd $ timeVelocity velocityVerlet

--- a/contents/verlet_integration/code/haskell/verlet.hs
+++ b/contents/verlet_integration/code/haskell/verlet.hs
@@ -52,13 +52,13 @@ main = do
         let (_, v, _, t) = last $ takeWhile aboveGround $ trajectory m freefall dt p0
          in (show t, show v)
 
-  print "[#] Time for Verlet integration is:"
-  print $ fst $ timeVelocity verlet
-  print "[#] Time for Stormer Verlet integration is:"
-  print $ fst $ timeVelocity stormerVerlet
-  print "[#] Velocity for Stormer Verlet integration is:"
-  print $ snd $ timeVelocity stormerVerlet
-  print "[#] Time for velocity Verlet integration is:"
-  print $ fst $ timeVelocity velocityVerlet
-  print "[#] Velocity for velocity Verlet integration is:"
-  print $ snd $ timeVelocity velocityVerlet
+  putStrLn "[#] Time for Verlet integration is:"
+  putStrLn $ fst $ timeVelocity verlet
+  putStrLn "[#] Time for Stormer Verlet integration is:"
+  putStrLn $ fst $ timeVelocity stormerVerlet
+  putStrLn "[#] Velocity for Stormer Verlet integration is:"
+  putStrLn $ snd $ timeVelocity stormerVerlet
+  putStrLn "[#] Time for velocity Verlet integration is:"
+  putStrLn $ fst $ timeVelocity velocityVerlet
+  putStrLn "[#] Velocity for velocity Verlet integration is:"
+  putStrLn $ snd $ timeVelocity velocityVerlet

--- a/contents/verlet_integration/code/java/Verlet.java
+++ b/contents/verlet_integration/code/java/Verlet.java
@@ -65,14 +65,20 @@ public class Verlet {
     public static void main(String[] args) {
 
         double verletTime = verlet(5.0, -10, 0.01);
-        System.out.println("Time for Verlet integration is: " + verletTime);
+        System.out.println("[#] Time for Verlet integration is:");
+        System.out.println(verletTime);
       
         VerletValues stormerVerlet = stormer_verlet(5.0, -10, 0.01);
-        System.out.println("Time for Stormer Verlet integration is: " + stormerVerlet.time);
-        System.out.println("Velocity for Stormer Verlet integration is: " + stormerVerlet.vel);
+        System.out.println("[#] Time for Stormer Verlet integration is:");
+        System.out.println(stormerVerlet.time);
+        System.out.println("[#] Velocity for Stormer Verlet integration is:");
+        System.out.println(stormerVerlet.vel);
         
         VerletValues velocityVerlet = velocity_verlet(5.0, -10, 0.01);
-        System.out.println("Time for velocity Verlet integration is: " + velocityVerlet.time);
-        System.out.println("Velocity for velocity Verlet integration is: " + velocityVerlet.vel);
+        System.out.println("[#] Time for velocity Verlet integration is:");
+        System.out.println(velocityVerlet.time);
+        System.out.println("[#] Velocity for velocity Verlet integration is:");
+        System.out.println(velocityVerlet.vel);
+        
     }
 }

--- a/contents/verlet_integration/code/javascript/verlet.js
+++ b/contents/verlet_integration/code/javascript/verlet.js
@@ -45,12 +45,17 @@ function velocityVerlet(pos, acc, dt) {
 }
 
 const time = verlet(5, -10, 0.01);
-console.log(`Time for Verlet integration is: ${time}\n`);
+console.log(`[#] Time for Verlet integration is:`);
+console.log(`${time}`);
 
 const stormer = stormerVerlet(5, -10, 0.01);
-console.log(`Time for Stormer Verlet integration is: ${stormer.time}`);
-console.log(`Velocity for Stormer Verlet integration is: ${stormer.vel}\n`);
+console.log(`[#] Time for Stormer Verlet integration is:`);
+console.log(`${stormer.time}`);
+console.log(`[#] Velocity for Stormer Verlet integration is:`);
+console.log(`${stormer.vel}`);
 
 const velocity = velocityVerlet(5, -10, 0.01);
-console.log(`Time for Velocity Verlet integration is: ${velocity.time}`);
-console.log(`Velocity for Velocity Verlet integration is: ${velocity.vel}\n`);
+console.log(`[#] Time for velocity Verlet integration is:`);
+console.log(`${velocity.time}`);
+console.log(`[#] Velocity for velocity Verlet integration is:`);
+console.log(`${velocity.vel}`);

--- a/contents/verlet_integration/code/julia/verlet.jl
+++ b/contents/verlet_integration/code/julia/verlet.jl
@@ -46,15 +46,21 @@ end
 
 function main()
     time = verlet(5.0, -10.0, 0.01);
-    println("Time for Verlet integration is: $(time)\n")
+    println("[#] Time for Verlet integration is:")
+    println("$(time)")
 
     time, vel = stormer_verlet(5.0, -10.0, 0.01);
-    println("Time for Stormer Verlet integration is: $(time)")
-    println("Velocity for Stormer Verlet integration is: $(vel)\n")
-
+    println("[#] Time for Stormer Verlet integration is:")
+    println("$(time)")
+    println("[#] Velocity for Stormer Verlet integration is:")
+    println("$(vel)")
+    
     time, vel = velocity_verlet(5.0, -10.0, 0.01);
-    println("Time for velocity Verlet integration is: $(time)")
-    println("Velocity for velocity Verlet integration is: $(vel)\n")
+    println("[#] Time for velocity Verlet integration is:")
+    println("$(time)")
+    println("[#] Velocity for velocity Verlet integration is:")
+    println("$(vel)")
+
 end
 
 main()

--- a/contents/verlet_integration/code/kotlin/verlet.kt
+++ b/contents/verlet_integration/code/kotlin/verlet.kt
@@ -43,13 +43,18 @@ fun velocityVerlet(_pos: Double, acc: Double, dt: Double): VerletValues {
 
 fun main(args: Array<String>) {
     val verletTime = verlet(5.0, -10.0, 0.01)
-    println("Time for Verlet integration is: $verletTime")
+    println("[#] Time for Verlet integration is:")
+    println("$verletTime")
 
     val stormerVerlet = stormerVerlet(5.0, -10.0, 0.01)
-    println("Time for Stormer Verlet integration is: $stormerVerlet.time")
-    println("Velocity for Stormer Verlet integration is: $stormerVerlet.vel")
+    println("[#] Time for Stormer Verlet integration is:")
+    println("${stormerVerlet.time}")
+    println("[#] Velocity for Stormer Verlet integration is:")
+    println("${stormerVerlet.vel}")
 
     val velocityVerlet = velocityVerlet(5.0, -10.0, 0.01)
-    println("Time for Velocity Verlet integration is: $velocityVerlet.time")
-    println("Velocity for Velocity Verlet integration is: $velocityVerlet.vel")
+    println("[#] Time for Velocity Verlet integration is:")
+    println("${velocityVerlet.time}")
+    println("[#] Velocity for Velocity Verlet integration is:")
+    println("${velocityVerlet.vel}")
 }

--- a/contents/verlet_integration/code/nim/verlet.nim
+++ b/contents/verlet_integration/code/nim/verlet.nim
@@ -46,12 +46,17 @@ func velocityVerlet(pos_in, acc, dt: float): (float, float) =
 
 when isMainModule:
   let timeV = verlet(5.0, -10.0, 0.01)
-  echo "Time for Verlet integration is: ", timeV
+  echo "[#] Time for Verlet integration is:"
+  echo timeV
 
   let (timeSV, velSV) = stormerVerlet(5.0, -10.0, 0.01)
-  echo "Time for Stormer Verlet integration is: ", timeSV
-  echo "Velocity for Stormer Verlet integration is: ", velSV
+  echo "[#] Time for Stormer Verlet integration is:"
+  echo timeSV
+  echo "[#] Velocity for Stormer Verlet integration is:"
+  echo velSV
 
   let (timeVV, velVV) = velocityVerlet(5.0, -10.0, 0.01)
-  echo "Time for velocity Verlet integration is: ", timeVV
-  echo "Velocity for velocity Verlet integration is: ", velVV
+  echo "[#] Time for velocity Verlet integration is:"
+  echo timeVV
+  echo "[#] Velocity for velocity Verlet integration is:"
+  echo velVV

--- a/contents/verlet_integration/code/python/verlet.py
+++ b/contents/verlet_integration/code/python/verlet.py
@@ -35,21 +35,21 @@ def velocity_verlet(pos, acc, dt):
 
 def main():
     time = verlet(5, -10, 0.01)
-    print("Verlet")
-    print("Time: {:.10f}".format(time))
-    print()
+    print("[#] Time for Verlet integration is:")
+    print("{:.10f}".format(time))
 
     time, vel = stormer_verlet(5, -10, 0.01)
-    print("Stormer-Verlet")
-    print("Time: {:.10f}".format(time))
-    print("Velocity: {:.10f}".format(vel))
-    print()
+    print("[#] Time for Stormer Verlet integration is:")
+    print("{:.10f}".format(time))
+    print("[#] Velocity for Stormer Verlet integration is:")
+    print("{:.10f}".format(vel))
 
     time, vel = velocity_verlet(5, -10, 0.01)
-    print("Velocity Verlet")
-    print("Time: {:.10f}".format(time))
-    print("Velocity: {:.10f}".format(vel))
-    print()
+    print("[#] Time for velocity Verlet integration is:")
+    print("{:.10f}".format(time))
+    print("[#] Velocity for velocity Verlet integration is:")
+    print("{:.10f}".format(vel))
+
 
 if __name__ == '__main__':
     main()

--- a/contents/verlet_integration/code/ruby/verlet.rb
+++ b/contents/verlet_integration/code/ruby/verlet.rb
@@ -27,7 +27,7 @@ def stormer_verlet(pos, acc, dt)
         vel += acc*dt
     end
 
-   return time
+   return time, vel
 
 end
 
@@ -41,10 +41,21 @@ def velocity_verlet(pos, acc, dt)
         vel += acc*dt
     end
 
-   return time
+   return time, vel
 
 end
 
+puts "[#] Time for Verlet integration is:"
 p verlet(5.0, -10, 0.01)
-p stormer_verlet(5.0, -10, 0.01)
-p velocity_verlet(5.0, -10, 0.01)
+
+time, vel = stormer_verlet(5.0, -10, 0.01)
+puts "[#] Time for Stormer Verlet integration is:"
+p time
+puts "[#] Velocity for Stormer Verlet integration is:"
+p vel
+
+time, vel = velocity_verlet(5.0, -10, 0.01)
+puts "[#] Time for velocity Verlet integration is:"
+p time
+puts "[#] Velocity for velocity Verlet integration is:"
+p vel

--- a/contents/verlet_integration/code/rust/verlet.rs
+++ b/contents/verlet_integration/code/rust/verlet.rs
@@ -49,13 +49,16 @@ fn main() {
     let (time_sv, vel_sv) = stormer_verlet(5.0, -10.0, 0.01);
     let (time_vv, vel_vv) = velocity_verlet(5.0, -10.0, 0.01);
 
-    println!("Time for original Verlet integration: {}", time_v);
-    println!(
-        "Time and velocity for Stormer Verlet integration: {}, {}",
-        time_sv, vel_sv
-    );
-    println!(
-        "Time and velocity for velocity Verlet integration: {}, {}",
-        time_vv, vel_vv
-    );
+    println!("[#] Time for Verlet integration is:");
+    println!("{}", time_v);
+    
+    println!("[#] Time for Stormer Verlet integration is:");
+    println!("{}", time_sv);
+    println!("[#] Velocity for Stormer Verlet integration is:");
+    println!("{}", vel_sv);
+    
+    println!("[#] Time for velocity Verlet integration is:");
+    println!("{}", time_vv);
+    println!("[#] Velocity for velocity Verlet integration is:");
+    println!("{}", vel_vv);
 }

--- a/contents/verlet_integration/code/swift/verlet.swift
+++ b/contents/verlet_integration/code/swift/verlet.swift
@@ -50,15 +50,20 @@ func velocityVerlet(pos: Double, acc: Double, dt: Double) -> (time: Double, vel:
 
 func main() {
     let verletTime = verlet(pos: 5.0, acc: -10.0, dt: 0.01)
-    print("Time for Verlet integration is: \(verletTime)")
+    print("[#] Time for Verlet integration is:")
+    print("\(verletTime)")
     
     let stormer = stormerVerlet(pos: 5.0, acc: -10.0, dt: 0.01);
-    print("Time for Stormer Verlet integration is: \(stormer.time)")
-    print("Velocity for Stormer Verlet integration is: \(stormer.vel)")
+    print("[#] Time for Stormer Verlet integration is:")
+    print("\(stormer.time)")
+    print("[#] Velocity for Stormer Verlet integration is:")
+    print("\(stormer.vel)")
     
     let velVerlet = velocityVerlet(pos: 5.0, acc: -10, dt: 0.01)
-    print("Time for velocity Verlet integration is: \(velVerlet.time)")
-    print("Velocity for velocity Verlet integration is: \(velVerlet.vel)")
+    print("[#] Time for velocity Verlet integration is:")
+    print("\(velVerlet.time)")
+    print("[#] Velocity for velocity Verlet integration is:")
+    print("\(velVerlet.vel)")
 }
 
 main()


### PR DESCRIPTION
This PR tries to standardize the different kinds of outputs to use the ones outlined in #824.

The following implementations are not [yet] standardized:

- ~~asm-x64~~ (done thanks to @leios)
- ~~haskell~~ (done thanks to @jiegillet)
- labview (does not have text output)
- matlab (does not have text output)
- scratch (does not have text output)

As I am not comfortable enough changing the asm/haskell code, someone else should take a look at these implementations.

I can confirm that every (standardized) implementation now produces the same [numerical] results as the julia one and that no `md` files need to be modified here.

Please review this carefully, as this kind of output standardization needs to be done for every chapter and this PR sets the ground rules for future optimizations.
