### PR TITLE
Fix asm exit codes

### DIFF
--- a/contents/monte_carlo_integration/code/asm-x64/monte_carlo.s
+++ b/contents/monte_carlo_integration/code/asm-x64/monte_carlo.s
@@ -84,5 +84,6 @@ main:
   call   printf
   add    rsp, 16
   pop    rbp
+  xor    rax, rax                   # Set exit code to 0
   ret
 

--- a/contents/verlet_integration/code/asm-x64/verlet.s
+++ b/contents/verlet_integration/code/asm-x64/verlet.s
@@ -124,5 +124,6 @@ main:
   mov    rax, 1
   call   printf
   pop    rbp
+  xor    rax, rax                      # Set exit code to 0
   ret
 


### PR DESCRIPTION
This PR fixes the asm implementations which previously did not return 0 as an exit code.

The affected implementations are the following:
- Verlet Integration
- Monte Carlo Method

This was already done in some others, but this aims to standardize it across different implementations.