### PR TITLE
Force SCons to use GCC when building .c files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -15,7 +15,7 @@ env = Environment(ENV={'PATH': os.environ['PATH']})
 env['CC'] = 'gcc'
 for tool in ['gcc','gnulink']:
    env.Tool(tool)
-env['CCFLAGS']=''
+env['CCFLAGS'] = ''
 
 # Add other languages here when you want to add language targets
 languages = ['c']

--- a/SConstruct
+++ b/SConstruct
@@ -10,12 +10,7 @@ To run the compilation for all implmeentations in one language, e.g. Rust, run t
 from pathlib import Path
 import os
 
-env = Environment(ENV={'PATH': os.environ['PATH']})
-
-env['CC'] = 'gcc'
-for tool in ['gcc','gnulink']:
-   env.Tool(tool)
-env['CCFLAGS']=''
+env = Environment(ENV={'PATH': os.environ['PATH']}, tools=['gcc', 'default'])
 
 # Add other languages here when you want to add language targets
 languages = ['c']
@@ -23,4 +18,4 @@ languages = ['c']
 env.C = env.Program
 
 SConscript('SConscript', exports='env languages')
-
+Default('build/c')

--- a/SConstruct
+++ b/SConstruct
@@ -10,7 +10,12 @@ To run the compilation for all implmeentations in one language, e.g. Rust, run t
 from pathlib import Path
 import os
 
-env = Environment(ENV={'PATH': os.environ['PATH']}, tools=['gcc', 'default'])
+env = Environment(ENV={'PATH': os.environ['PATH']})
+
+env['CC'] = 'gcc'
+for tool in ['gcc','gnulink']:
+   env.Tool(tool)
+env['CCFLAGS']=''
 
 # Add other languages here when you want to add language targets
 languages = ['c']
@@ -18,4 +23,4 @@ languages = ['c']
 env.C = env.Program
 
 SConscript('SConscript', exports='env languages')
-Default('build/c')
+

--- a/SConstruct
+++ b/SConstruct
@@ -8,8 +8,14 @@ Currently, the aim is to provide a way to compile or copy the implementation fil
 To run the compilation for all implmeentations in one language, e.g. Rust, run the command `scons build/c`, and the resulting executables will be available in the `cuild/c` directory, each in their respective algorithm directory, containing the executable."""
 
 from pathlib import Path
+import os
 
-env = Environment()
+env = Environment(ENV={'PATH': os.environ['PATH']})
+
+env['CC'] = 'gcc'
+for tool in ['gcc','gnulink']:
+   env.Tool(tool)
+env['CCFLAGS']=''
 
 # Add other languages here when you want to add language targets
 languages = ['c']


### PR DESCRIPTION
This fixes SCons on Windows when MSVC is installed.  Previously it would attempt to use MSVC, but fail due to trying to pass it gcc libraries to link.

This needs testing on Linux before it is merged.

It may be better to have the sconstruct file detect which compiler is being used and adjust the calling based on that, so users with only MSVC or with clang can also build. Fixing it for now would still seem prudent, and we can change the behaviour later if wanted.