### PR TITLE
Added x64 assembly compilation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -11,9 +11,10 @@ from pathlib import Path
 import os
 
 env = Environment(ENV={'PATH': os.environ['PATH']},
-		  tools=['gcc', 'gnulink', 'g++'])
+		  tools=['gcc', 'gnulink', 'g++', 'gas'])
 
-env['AS'] = 'as'
+env['ASFLAGS'] = '--64'
+
 env['CCFLAGS'] = ''
 env['CXXFLAGS'] = '-std=c++17'
 

--- a/SConstruct
+++ b/SConstruct
@@ -13,18 +13,20 @@ import os
 env = Environment(ENV={'PATH': os.environ['PATH']})
 
 env['CC'] = 'gcc'
+env['AS'] = 'as'
 for tool in ['gcc','gnulink']:
    env.Tool(tool)
 env['CCFLAGS'] = ''
 env['CXXFLAGS'] = '-std=c++17'
+env['LINKFLAGS'] = '-no-pie'
 
 # Add other languages here when you want to add language targets
 # Put 'name_of_language_directory' : 'file_extension'
-languages = {'c': 'c', 'cpp': 'cpp'}
+languages = {'c': 'c', 'cpp': 'cpp', 'asm-x64': 's'}
 
 env.C = env.Program
 env.CPlusPlus = env.Program
-
+env.X64 = env.Program
 
 Export('env')
 
@@ -46,7 +48,8 @@ sconscript_dir_path = Path('sconscripts')
 for language, files in files_to_compile.items():
     if files:
         if (sconscript_path := sconscript_dir_path / f"{language}_SConscript").exists():
-            SConscript(sconscript_path, exports = {'files_to_compile': files})
+            SConscript(sconscript_path, exports = {'files_to_compile': files,
+                                                   'language': language})
         else:
             print(f'{language} file found at {files[0]}, but no sconscript file is present ')
 

--- a/SConstruct
+++ b/SConstruct
@@ -10,12 +10,10 @@ To run the compilation for all implementations in one language, e.g. C, run the 
 from pathlib import Path
 import os
 
-env = Environment(ENV={'PATH': os.environ['PATH']})
+env = Environment(ENV={'PATH': os.environ['PATH']},
+		  tools=['gcc', 'gnulink', 'g++'])
 
-env['CC'] = 'gcc'
 env['AS'] = 'as'
-for tool in ['gcc','gnulink']:
-   env.Tool(tool)
 env['CCFLAGS'] = ''
 env['CXXFLAGS'] = '-std=c++17'
 

--- a/SConstruct
+++ b/SConstruct
@@ -18,7 +18,6 @@ for tool in ['gcc','gnulink']:
    env.Tool(tool)
 env['CCFLAGS'] = ''
 env['CXXFLAGS'] = '-std=c++17'
-env['LINKFLAGS'] = '-no-pie'
 
 # Add other languages here when you want to add language targets
 # Put 'name_of_language_directory' : 'file_extension'

--- a/contents/cooley_tukey/code/asm-x64/SConscript
+++ b/contents/cooley_tukey/code/asm-x64/SConscript
@@ -3,4 +3,4 @@ from pathlib import Path
 
 dirname = Path.cwd().parents[1].stem
 
-env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS=['m'])
+env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS=['m'], parse_flags="-Wl,-no-pie")

--- a/contents/cooley_tukey/code/asm-x64/SConscript
+++ b/contents/cooley_tukey/code/asm-x64/SConscript
@@ -1,0 +1,6 @@
+Import('*')
+from pathlib import Path
+
+dirname = Path.cwd().parents[1].stem
+
+env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS=['m'])

--- a/contents/cooley_tukey/code/asm-x64/SConscript
+++ b/contents/cooley_tukey/code/asm-x64/SConscript
@@ -3,4 +3,4 @@ from pathlib import Path
 
 dirname = Path.cwd().parents[1].stem
 
-env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS=['m'], parse_flags="-Wl,-no-pie")
+env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS=['m'], LINKFLAGS='-no-pie')

--- a/contents/forward_euler_method/code/asm-x64/SConscript
+++ b/contents/forward_euler_method/code/asm-x64/SConscript
@@ -1,0 +1,6 @@
+Import('*')
+from pathlib import Path
+
+dirname = Path.cwd().parents[1].stem
+
+env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS='m')

--- a/contents/forward_euler_method/code/asm-x64/SConscript
+++ b/contents/forward_euler_method/code/asm-x64/SConscript
@@ -3,4 +3,4 @@ from pathlib import Path
 
 dirname = Path.cwd().parents[1].stem
 
-env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS='m', parse_flags="-Wl,-no-pie")
+env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS='m', LINKFLAGS='-no-pie')

--- a/contents/forward_euler_method/code/asm-x64/SConscript
+++ b/contents/forward_euler_method/code/asm-x64/SConscript
@@ -3,4 +3,4 @@ from pathlib import Path
 
 dirname = Path.cwd().parents[1].stem
 
-env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS='m')
+env.X64(f'#/build/asm-x64/{dirname}', Glob('*.s'), LIBS='m', parse_flags="-Wl,-no-pie")

--- a/sconscripts/asm-x64_SConscript
+++ b/sconscripts/asm-x64_SConscript
@@ -3,4 +3,4 @@ from pathlib import Path
 
 for file in files_to_compile:
     chapter_name = file.parent.parent.parent.stem
-    env.X64(f'#/build/{language}/{chapter_name}', str(file), parse_flags="-Wl,-no-pie")
+    env.X64(f'#/build/{language}/{chapter_name}', str(file), LINKFLAGS='-no-pie')

--- a/sconscripts/asm-x64_SConscript
+++ b/sconscripts/asm-x64_SConscript
@@ -1,0 +1,6 @@
+Import('files_to_compile language env')
+from pathlib import Path
+
+for file in files_to_compile:
+    chapter_name = file.parent.parent.parent.stem
+    env.X64(f'#/build/{language}/{chapter_name}', str(file))

--- a/sconscripts/asm-x64_SConscript
+++ b/sconscripts/asm-x64_SConscript
@@ -3,4 +3,4 @@ from pathlib import Path
 
 for file in files_to_compile:
     chapter_name = file.parent.parent.parent.stem
-    env.X64(f'#/build/{language}/{chapter_name}', str(file))
+    env.X64(f'#/build/{language}/{chapter_name}', str(file), parse_flags="-Wl,-no-pie")


### PR DESCRIPTION
And here we go again with X64 Assembly.

There was a little annoyance this time: the way we programmed the assembly required the compilation to use the link flag `-no-pie`. As such, to prevent environment duplication, I elected to add the link flag to all the executables.

Apart from this, compilation was not affected, and all executables compile successfully on my Linux machine.

We really should set up a Windows environment to check whether it works as intended there, though.