### PR TITLE
Added Fortran compilation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,7 +17,7 @@ rust_rustc_builder = Builder(action='rustc $SOURCE -o $TARGET$PROGSUFFIX')
 
 env = Environment(ENV=os.environ,
                   BUILDERS={'rustc': rust_rustc_builder, 'cargo': rust_cargo_builder},
-                  tools=['gcc', 'gnulink', 'g++', 'gas'])
+                  tools=['gcc', 'gnulink', 'g++', 'gas', 'gfortran'])
 
 env['CCFLAGS'] = ''
 env['CXXFLAGS'] = '-std=c++17'
@@ -25,11 +25,18 @@ env['ASFLAGS'] = '--64'
 
 # Add other languages here when you want to add language targets
 # Put 'name_of_language_directory' : 'file_extension'
-languages = {'c': 'c', 'cpp': 'cpp', 'asm-x64': 's', 'rust': 'rs'}
+languages = {
+    'c': 'c',
+    'cpp': 'cpp',
+    'asm-x64': 's',
+    'rust': 'rs',
+    'fortran': 'f90',
+}
 
 env.C = env.Program
 env.CPlusPlus = env.Program
 env.X64 = env.Program
+env.Fortran = env.Program
 
 Export('env')
 

--- a/SConstruct
+++ b/SConstruct
@@ -34,7 +34,7 @@ languages = {
     'cpp': 'cpp',
     'asm-x64': 's',
     'rust': 'rs',
-    'go': 'go'
+    'go': 'go',
     'fortran': 'f90',
 }
 

--- a/contents/euclidean_algorithm/code/fortran/SConscript
+++ b/contents/euclidean_algorithm/code/fortran/SConscript
@@ -1,0 +1,6 @@
+Import('*')
+from pathlib import Path
+
+dirname = Path.cwd().parents[1].stem
+
+env.Fortran(f'#/build/fortran/{dirname}', 'euclidean.f90')

--- a/sconscripts/fortran_SConscript
+++ b/sconscripts/fortran_SConscript
@@ -1,0 +1,6 @@
+Import('files_to_compile env')
+from pathlib import Path
+
+for file in files_to_compile:
+    chapter_name = file.parent.parent.parent.stem
+    env.Fortran(f'#/build/fortran/{chapter_name}', str(file))


### PR DESCRIPTION
And here we go with the next language: Fortran.

Adding it was straightforward since there was no library to add.

The only problem was the double definition of the `build/fortran/euclidean_algorithm` target, which I had to create a SConscript for.﻿
