### PR TITLE
Change the "Publish Container" Action to only run in the main repository

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'algorithm-archivists/algorithm-archive'
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry


### PR DESCRIPTION
This prevents this action from failing in forked repositories