### PR TITLE
Removed C/C++ warnings only for C++

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -23,7 +23,7 @@ env = Environment(ENV=os.environ,
                             'Go': go_builder},
                   tools=['gcc', 'gnulink', 'g++', 'gas', 'gfortran'])
 
-env['CCFLAGS'] = '-Wall -Wextra -Werror'
+env['CFLAGS'] = '-Wall -Wextra -Werror'
 env['CXXFLAGS'] = '-std=c++17'
 env['ASFLAGS'] = '--64'
 


### PR DESCRIPTION
This is a PR to remove the expectations of no warning for C++﻿, to allow for some time to fix the C++ warnings properly.

Before running SCons in a pipeline, we need to remove the warnings in C++, as they would give wrong results.
