### PR TITLE
IFS: Standardize output files

### DIFF
--- a/contents/IFS/code/c/IFS.c
+++ b/contents/IFS/code/c/IFS.c
@@ -30,15 +30,15 @@ void chaos_game(struct point *in, size_t in_n, struct point *out,
 
 int main() {
     struct point shape_points [3] = {{0.0,0.0}, {0.5,sqrt(0.75)}, {1.0,0.0}};
-    struct point out_points[1000];
+    struct point out_points[10000];
 
     srand(time(NULL));
 
-    chaos_game(shape_points, 3, out_points, 1000);
+    chaos_game(shape_points, 3, out_points, 10000);
 
     FILE *fp = fopen("sierpinksi.dat", "w+");
 
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 10000; ++i) {
         fprintf(fp, "%f\t%f\n", out_points[i].x, out_points[i].y);
     }
 

--- a/contents/IFS/code/c/IFS.c
+++ b/contents/IFS/code/c/IFS.c
@@ -29,16 +29,18 @@ void chaos_game(struct point *in, size_t in_n, struct point *out,
 }
 
 int main() {
+    const int point_count = 10000;
+    
     struct point shape_points [3] = {{0.0,0.0}, {0.5,sqrt(0.75)}, {1.0,0.0}};
-    struct point out_points[10000];
+    struct point out_points[point_count];
 
     srand(time(NULL));
 
-    chaos_game(shape_points, 3, out_points, 10000);
+    chaos_game(shape_points, 3, out_points, point_count);
 
     FILE *fp = fopen("sierpinksi.dat", "w+");
 
-    for (int i = 0; i < 10000; ++i) {
+    for (int i = 0; i < point_count; ++i) {
         fprintf(fp, "%f\t%f\n", out_points[i].x, out_points[i].y);
     }
 
@@ -46,4 +48,3 @@ int main() {
 
     return 0;
 }
-

--- a/contents/IFS/code/clisp/ifs.lisp
+++ b/contents/IFS/code/clisp/ifs.lisp
@@ -21,7 +21,7 @@
     `((0 0) (0.5 ,(sqrt 0.75)) (1 0))))
 
 ;; output the data to the "out.dat" file
-(with-open-file (out "out.dat" :direction :output :if-exists :supersede)
+(with-open-file (out "sierpinski.dat" :direction :output :if-exists :supersede)
   (flet ((format-point (p)
            ;; this is not very clean, but it's the simplest way to insert a tab into a string.
            (format nil "~f~c~f" (point-x p) #\tab (point-y p))))

--- a/contents/IFS/code/haskell/IFS.hs
+++ b/contents/IFS/code/haskell/IFS.hs
@@ -27,4 +27,4 @@ main = do
       points = chaosGame g 10000 sierpinski
       showPoint (Point x y) = show x ++ "\t" ++ show y
 
-  writeFile "out.dat" $ intercalate "\n" $ map showPoint points
+  writeFile "sierpinski.dat" $ intercalate "\n" $ map showPoint points


### PR DESCRIPTION
This PR aims to standardize the output file name and the amount of points generated.

The output file will now always be named `sierpinski.dat` and it will contain 10000 points.