### PR TITLE
GitHub action tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
           HOME: /root
         run:  |
           . "$HOME/.cargo/env"
-          scons -Q
+          scons -Q $(git diff --name-only main | grep code | cut -s -d '/' -f4,2 | sed -r -e "s|(.*)/(.*)|build/\2/\1|" | tr '\n' ' ')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
           npx honkit build
           
       - name: Initalize cargo and run SCons
-        paths-ignore:
-        - '**.md'
         env:
           HOME: /root
         run:  |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
           npx honkit build
           
       - name: Initalize cargo and run SCons
+        paths-ignore:
+        - '**.md'
         env:
           HOME: /root
         run:  |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,15 @@ jobs:
         run: |
           npm install
           npx honkit build
-          
+      
+      - name: Diff code changes
+      run: |
+          echo "CODE_DIFF=$(git diff --name-only main | grep code | cut -s -d '/' -f4,2 | sed -r -e "s|(.*)/(.*)|build/\2/\1|" | tr '\n' ' ')" >> $GITHUB_ENV
+
       - name: Initalize cargo and run SCons
+        if: ${{ env.CODE_DIFF != '' }}
         env:
           HOME: /root
         run:  |
           . "$HOME/.cargo/env"
-          scons -Q $(git diff --name-only main | grep code | cut -s -d '/' -f4,2 | sed -r -e "s|(.*)/(.*)|build/\2/\1|" | tr '\n' ' ')
+          scons -Q 


### PR DESCRIPTION
I'm suggesting two changes to the pipeline:

~~-I'm adding a `path-ignore` to the scons build, so that in the case of having only `*.md` files that changed, to not retrigger the whole scons build.~~ Turns out that syntax isn't possible at the moment. We could find a different github action to help but I don't think it'll be useful.

- It's more of a Proof of Concept at this point, but I'm suggesting a change that should only run scons on modified chapter code