### PR TITLE
Fixed Coconut compilation problem

### DIFF
--- a/sconscripts/coconut_SConscript
+++ b/sconscripts/coconut_SConscript
@@ -1,6 +1,6 @@
 Import('files_to_compile env')
 
 for file_info in files_to_compile:
-    build_target = f'#/build/{file_info.language}/{file_info.chapter}/{file_info.path.stem}'
+    build_target = f'#/build/{file_info.language}/{file_info.chapter}/{file_info.path.stem}.py'
     build_result = env.Coconut(build_target, str(file_info.path))
     env.Alias(str(file_info.chapter), build_result)


### PR DESCRIPTION
The issue this PR fixes is the following:

When building for the first time, the Coconut compiler considers the build target a directory.
However, when running a second time, SCons is confused because it expected a file.

This can be fixed by adding the `.py` suffix to the build target (see the Coconut SConscript).
﻿
