### PR TITLE
Solved formatting problems

### DIFF
--- a/contents/IFS/IFS.md
+++ b/contents/IFS/IFS.md
@@ -20,8 +20,8 @@ To begin the discussion of Iterated Function Systems (IFSs), we will first discu
 <img class="center" src="res/IFS_triangle_1.png" alt="Sierpinsky Triangle Chaos Game"  style="width:100%">
 
 This image is clearly a set of triangles embedded in a larger triangle in such a way that it can be continually cut into three identical pieces and still retain its internal structure.
-This idea is known as self-similarity {{"self-similar" | cite }}, and it is usually the first aspect of fractals to catch an audience's attention.
-In fact, there are plenty of uses of fractals and their mathematical underpinnings, such as estimating the coastline of Britain {{ "mandelbrot1967long" | cite}}, identifying fingerprints {{ "jampour2010new" | cite }}, and image compression {{ "fractal-compression" | cite }}{{ "saupe1994review" | cite }}.
+This idea is known as self-similarity {{ "self-similar" | cite }}, and it is usually the first aspect of fractals to catch an audience's attention.
+In fact, there are plenty of uses of fractals and their mathematical underpinnings, such as estimating the coastline of Britain {{ "mandelbrot1967long" | cite }}, identifying fingerprints {{ "jampour2010new" | cite }}, and image compression {{ "fractal-compression" | cite }}{{ "saupe1994review" | cite }}.
 In many more rigorous definitions, a fractal can be described as any system that has a non-integer Hausdorff dimension {{ "3b1bfractal" | cite }}{{ "hausdorff" | cite }}{{ "gneiting2012estimators" | cite }}.
 Though this is an incredibly interesting concept, the discussion of this chapter will instead focus on methods to generate fractal patterns through iterated function systems.
 
@@ -41,7 +41,7 @@ f_3(P) &= \frac{P + C}{2}\\
 $$
 
 Each function will read in a particular location in space (here, $$P \in \mathbb{R}^2$$) and output a new location that is the midpoint between the input location and $$A$$, $$B$$, or $$C$$ for $$f_1$$, $$f_2$$, and $$f_3$$ respectively.
-The union of all of these functions (the set of all possible functions available for use) is often notated as the _Hutchinson operator_ {{ "hutchinson-operator" | cite }}{{ "hutchinson1981fractals" | cite}}, and for this case it would look like this:
+The union of all of these functions (the set of all possible functions available for use) is often notated as the _Hutchinson operator_ {{ "hutchinson-operator" | cite }}{{ "hutchinson1981fractals" | cite }}, and for this case it would look like this:
 
 $$
 H(P) = \bigcup_{i=1}^3f_i(P)

--- a/contents/stacks_and_queues/stacks_and_queues.md
+++ b/contents/stacks_and_queues/stacks_and_queues.md
@@ -19,10 +19,9 @@ Here is a simple implementation of a stack:
 {% sample lang="ts" %}
 [import, lang:"typescript"](code/typescript/stack.ts)
 {% sample lang="java" %}
-[import, lang:"java"](code/java/Stack.java)
+[import, lang:"java"](code/java/StackTest.java)
 {% sample lang = "cpp"%}
 [import, lang:"cpp"](code/cpp/stack.cpp)
-[import, lang:"java"](code/java/StackTest.java)
 {% sample lang="rust" %}
 [import, lang:"rust"](code/rust/Stack.rs)
 {% endmethod %}
@@ -32,10 +31,9 @@ Here is a simple implementation of a queue:
 {% sample lang="ts" %}
 [import, lang:"typescript"](code/typescript/queue.ts)
 {% sample lang="java" %}
-[import, lang:"java" ](code/java/Queue.java)
+[import, lang:"java" ](code/java/QueueTest.java)
 {% sample lang = "cpp"%}
 [import, lang:"cpp"](code/cpp/queue.cpp)
-[import, lang:"java" ](code/java/QueueTest.java)
 {% sample lang="rust" %}
 [import, lang:"rust" ](code/rust/Queue.rs)
 {% endmethod %}


### PR DESCRIPTION
I opened this PR to solve some critical formatting problems, that were incompatible with AAA-py rendering.

Rendering with AAA-py is blocked until this PR is merged, although Honkit works correctly with it (at least failure is not fatal).

However, the Java `Stack and Queues` chapter code inclusion is broken in all cases, and this fixes that problem.

