### PR TITLE
Eliminating C/C++ implicit conversions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -60,7 +60,7 @@ for language, tools in languages_to_import.items():
 
 Export('env')
 
-env['CCFLAGS'] = '-Wall -Wextra -Werror -pedantic'
+env['CCFLAGS'] = '-Wall -Wextra -Werror -pedantic -Wconversion'
 env['CFLAGS'] = '-std=gnu99'
 env['CXXFLAGS'] = '-std=c++17 -Wold-style-cast'
 env['ASFLAGS'] = '--64'

--- a/contents/IFS/code/c/IFS.c
+++ b/contents/IFS/code/c/IFS.c
@@ -29,18 +29,18 @@ void chaos_game(struct point *in, size_t in_n, struct point *out,
 }
 
 int main() {
-    const int point_count = 10000;
+    const size_t point_count = 10000;
     
     struct point shape_points [3] = {{0.0,0.0}, {0.5,sqrt(0.75)}, {1.0,0.0}};
     struct point out_points[point_count];
 
-    srand(time(NULL));
+    srand((unsigned int)time(NULL));
 
     chaos_game(shape_points, 3, out_points, point_count);
 
     FILE *fp = fopen("sierpinksi.dat", "w+");
 
-    for (int i = 0; i < point_count; ++i) {
+    for (size_t i = 0; i < point_count; ++i) {
         fprintf(fp, "%f\t%f\n", out_points[i].x, out_points[i].y);
     }
 

--- a/contents/approximate_counting/code/c/approximate_counting.c
+++ b/contents/approximate_counting/code/c/approximate_counting.c
@@ -40,7 +40,7 @@ double increment(double v, double a)
 // It returns n(v, a), the approximate count
 double approximate_count(size_t n_items, double a)
 {
-    int v = 0;
+    double v = 0;
     for (size_t i = 0; i < n_items; ++i) {
         v = increment(v, a);
     }
@@ -61,9 +61,10 @@ void test_approximation_count(size_t n_trials, size_t n_items, double a,
     for (size_t i = 0; i < n_trials; ++i) {
         sum += approximate_count(n_items, a);
     }
-    double avg = sum / n_trials;
+    double avg = sum / (double)n_trials;
 
-    if (fabs((avg - n_items) / n_items) < threshold){
+    double items = (double)n_items;
+    if (fabs((avg - items) / items) < threshold){
         printf("passed\n");
     }
     else{
@@ -73,7 +74,7 @@ void test_approximation_count(size_t n_trials, size_t n_items, double a,
 
 int main()
 {
-    srand(time(NULL));
+    srand((unsigned int)time(NULL));
 
     printf("[#]\nCounting Tests, 100 trials\n");
     printf("[#]\ntesting 1,000, a = 30, 10%% error\n");

--- a/contents/cooley_tukey/code/c/fft.c
+++ b/contents/cooley_tukey/code/c/fft.c
@@ -11,7 +11,7 @@ void fft(double complex *x, size_t n) {
     memset(y, 0, sizeof(y));
     fftw_plan p;
 
-    p = fftw_plan_dft_1d(n, (fftw_complex*)x, (fftw_complex*)y,
+    p = fftw_plan_dft_1d((int)n, (fftw_complex*)x, (fftw_complex*)y,
                          FFTW_FORWARD, FFTW_ESTIMATE);
 
     fftw_execute(p);
@@ -27,7 +27,7 @@ void dft(double complex *X, const size_t N) {
     for (size_t i = 0; i < N; ++i) {
         tmp[i] = 0;
         for (size_t j = 0; j < N; ++j) {
-            tmp[i] += X[j] * cexp(-2.0 * M_PI * I * j * i / N);
+            tmp[i] += X[j] * cexp(-2.0 * M_PI * I * (double)j * (double)i / (double)N);
         }
     }
 
@@ -49,7 +49,7 @@ void cooley_tukey(double complex *X, const size_t N) {
         cooley_tukey(X + N / 2, N / 2);
 
         for (size_t i = 0; i < N / 2; ++i) {
-            X[i + N / 2] = X[i] - cexp(-2.0 * I * M_PI * i / N) * X[i + N / 2];
+            X[i + N / 2] = X[i] - cexp(-2.0 * I * M_PI * (double)i / (double)N) * X[i + N / 2];
             X[i] -= (X[i + N / 2]-X[i]);
         }
     }
@@ -58,7 +58,7 @@ void cooley_tukey(double complex *X, const size_t N) {
 void bit_reverse(double complex *X, size_t N) {
     for (size_t i = 0; i < N; ++i) {
         size_t n = i;
-        int a = i;
+        size_t a = i;
         int count = (int)log2((double)N) - 1;
 
         n >>= 1;
@@ -67,7 +67,7 @@ void bit_reverse(double complex *X, size_t N) {
             count--;
             n >>= 1;
         }
-        n = (a << count) & ((1 << (int)log2((double)N)) - 1);
+        n = (a << count) & (size_t)((1 << (size_t)log2((double)N)) - 1);
 
         if (n > i) {
             double complex tmp = X[i];
@@ -81,8 +81,8 @@ void iterative_cooley_tukey(double complex *X, size_t N) {
     bit_reverse(X, N);
 
     for (int i = 1; i <= log2((double)N); ++i) {
-        size_t stride = pow(2, i);
-        double complex w = cexp(-2.0 * I * M_PI / stride);
+        size_t stride = (size_t)pow(2, i);
+        double complex w = cexp(-2.0 * I * M_PI / (double)stride);
         for (size_t j = 0; j < N; j += stride) {
             double complex v = 1.0;
             for (size_t k = 0; k < stride / 2; ++k) {
@@ -105,7 +105,7 @@ void approx(double complex *X, double complex *Y, size_t N) {
 }
 
 int main() {
-    srand(time(NULL));
+    srand((unsigned int)time(NULL));
     double complex x[64], y[64], z[64];
     for (size_t i = 0; i < 64; ++i) {
         x[i] = rand() / (double) RAND_MAX;

--- a/contents/cooley_tukey/code/cpp/fft.cpp
+++ b/contents/cooley_tukey/code/cpp/fft.cpp
@@ -55,7 +55,7 @@ void cooley_tukey(Iter first, Iter last) {
 
     // now combine each of those halves with the butterflies
     for (int k = 0; k < size / 2; ++k) {
-      auto w = std::exp(complex(0, -2.0 * pi * k / size));
+      auto w = std::exp(complex(0, -2.0 * pi * k / static_cast<double>(size)));
 
       auto& bottom = first[k];
       auto& top = first[k + size / 2];
@@ -78,7 +78,7 @@ void sort_by_bit_reverse(Iter first, Iter last) {
     b = (((b & 0xcccccccc) >> 2) | ((b & 0x33333333) << 2));
     b = (((b & 0xf0f0f0f0) >> 4) | ((b & 0x0f0f0f0f) << 4));
     b = (((b & 0xff00ff00) >> 8) | ((b & 0x00ff00ff) << 8));
-    b = ((b >> 16) | (b << 16)) >> (32 - std::uint32_t(log2(size)));
+    b = ((b >> 16) | (b << 16)) >> (32 - std::uint32_t(log2(static_cast<double>(size))));
     if (b > i) {
       swap(first[b], first[i]);
     }

--- a/contents/forward_euler_method/code/c/euler.c
+++ b/contents/forward_euler_method/code/c/euler.c
@@ -13,7 +13,7 @@ void solve_euler(double timestep, double *result, size_t n) {
 int check_result(double *result, size_t n, double threshold, double timestep) {
     int is_approx = 1;
     for (size_t i = 0; i < n; ++i) {
-        double solution = exp(-3.0 * i * timestep);
+        double solution = exp(-3.0 * (double)i * timestep);
         if (fabs(result[i] - solution) > threshold) {
             printf("%f    %f\n", result[i], solution);
             is_approx = 0;

--- a/contents/forward_euler_method/code/cpp/euler.cpp
+++ b/contents/forward_euler_method/code/cpp/euler.cpp
@@ -27,7 +27,7 @@ template <typename Iter>
 bool check_result(Iter first, Iter last, double threshold, double timestep) {
   auto it = first;
   for (size_t idx = 0; it != last; ++idx, ++it) {
-    double solution = std::exp(-3.0 * idx * timestep);
+    double solution = std::exp(-3.0 * static_cast<double>(idx) * timestep);
     if (std::abs(*it - solution) > threshold) {
       std::cout << "We found a value outside the threshold; the " << idx
                 << "-th value was " << *it << ", but the expected solution was "

--- a/contents/gaussian_elimination/code/cpp/gaussian_elimination.cpp
+++ b/contents/gaussian_elimination/code/cpp/gaussian_elimination.cpp
@@ -7,12 +7,12 @@
 
 void gaussianElimination(std::vector<std::vector<double> > &eqns) {
   // 'eqns' is the matrix, 'rows' is no. of vars
-  int rows = eqns.size(), cols = eqns[0].size();
+  std::size_t rows = eqns.size(), cols = eqns[0].size();
 
-  for (int i = 0; i < rows - 1; i++) {
-    int pivot = i;
+  for (std::size_t i = 0; i < rows - 1; i++) {
+      std::size_t pivot = i;
 
-    for (int j = i + 1; j < rows; j++) {
+    for (std::size_t j = i + 1; j < rows; j++) {
       if (fabs(eqns[j][i]) > fabs(eqns[pivot][i])) pivot = j;
     }
 
@@ -22,10 +22,10 @@ void gaussianElimination(std::vector<std::vector<double> > &eqns) {
     if (i != pivot)  // Swapping the rows if new row with higher maxVals is found
       std::swap(eqns[pivot], eqns[i]);  // C++ swap function
 
-    for (int j = i + 1; j < rows; j++) {
+    for (std::size_t j = i + 1; j < rows; j++) {
       double scale = eqns[j][i] / eqns[i][i];
 
-      for (int k = i + 1; k < cols; k++)   // k doesn't start at 0, since
+      for (std::size_t k = i + 1; k < cols; k++)   // k doesn't start at 0, since
         eqns[j][k] -= scale * eqns[i][k];  // values before from 0 to i
                                            // are already 0
       eqns[j][i] = 0.0;
@@ -35,9 +35,9 @@ void gaussianElimination(std::vector<std::vector<double> > &eqns) {
 
 void gaussJordan(std::vector<std::vector<double> > &eqns) {
   // 'eqns' is the (Row-echelon) matrix, 'rows' is no. of vars
-  int rows = eqns.size();
+  std::size_t rows = eqns.size();
 
-  for (int i = rows - 1; i >= 0; i--) {
+  for (std::size_t i = rows - 1; i < rows; i--) {
 
     if (eqns[i][i] != 0) {
 
@@ -45,7 +45,7 @@ void gaussJordan(std::vector<std::vector<double> > &eqns) {
       eqns[i][i] = 1;  // We know that the only entry in this row is 1
 
       // subtracting rows from below
-      for (int j = i - 1; j >= 0; j--) {
+      for (std::size_t j = i - 1; j < i; j--) {
         eqns[j][rows] -= eqns[j][i] * eqns[i][rows];
         eqns[j][i] = 0;  // We also set all the other values in row to 0 directly
       }
@@ -55,13 +55,13 @@ void gaussJordan(std::vector<std::vector<double> > &eqns) {
 
 std::vector<double> backSubs(const std::vector<std::vector<double> > &eqns) {
   // 'eqns' is matrix, 'rows' is no. of variables
-  int rows = eqns.size();
+  std::size_t rows = eqns.size();
 
   std::vector<double> ans(rows);
-  for (int i = rows - 1; i >= 0; i--) {
+  for (std::size_t i = rows - 1; i < rows; i--) {
     double sum = 0.0;
 
-    for (int j = i + 1; j < rows; j++) sum += eqns[i][j] * ans[j];
+    for (std::size_t j = i + 1; j < rows; j++) sum += eqns[i][j] * ans[j];
 
     if (eqns[i][i] != 0)
       ans[i] = (eqns[i][rows] - sum) / eqns[i][i];

--- a/contents/graham_scan/code/c/graham.c
+++ b/contents/graham_scan/code/c/graham.c
@@ -36,8 +36,8 @@ void polar_angles_sort(struct point *points, struct point origin, size_t size) {
 
     double pivot_angle = polar_angle(origin, points[size / 2]);
 
-    int i = 0;
-    int j = size - 1;
+    size_t i = 0;
+    size_t j = size - 1;
     while (1) {
         while (polar_angle(origin, points[i]) < pivot_angle) {
             i++;

--- a/contents/huffman_encoding/code/c/huffman.c
+++ b/contents/huffman_encoding/code/c/huffman.c
@@ -23,8 +23,8 @@ struct codebook {
 
 struct heap {
     struct tree** data;
-    int length;
-    int capacity;
+    size_t length;
+    size_t capacity;
 };
 
 bool is_leaf(const struct tree* t) {
@@ -39,21 +39,21 @@ void swap(struct tree** lhs, struct tree** rhs) {
 
 /* The two concat functions are horribly inefficient */
 void concat(char** dst, const char* src) {
-    int dst_len = strlen(*dst);
-    int src_len = strlen(src);
+    size_t dst_len = strlen(*dst);
+    size_t src_len = strlen(src);
     *dst = realloc(*dst, src_len + dst_len + 1);
     strcat(*dst, src);
 }
 
 void concat_char(char** dst, char c) {
-    int len = strlen(*dst);
+    size_t len = strlen(*dst);
     *dst = realloc(*dst, len + 2);
     (*dst)[len] = c;
     (*dst)[len + 1] = '\0';
 }
 
 char* duplicate(const char* src) {
-    int length = strlen(src);
+    size_t length = strlen(src);
     char* dst = malloc(length + 1);
     memcpy(dst, src, length + 1);
     return dst;
@@ -66,9 +66,9 @@ void heap_push(struct heap* heap, struct tree* value) {
     }
     heap->data[heap->length++] = value;
 
-    int index = heap->length - 1;
+    size_t index = heap->length - 1;
     while (index) {
-        int parent_index = (index - 1) / 2;
+        size_t parent_index = (index - 1) / 2;
         if (heap->data[parent_index]->count <= heap->data[index]->count) {
             break;
         }
@@ -86,11 +86,11 @@ struct tree* heap_pop(struct heap* heap) {
     struct tree* result = heap->data[0];
     swap(&heap->data[0], &heap->data[--heap->length]);
 
-    int index = 0;
+    size_t index = 0;
     for (;;) {
-        int target = index;
-        int left = 2 * index + 1;
-        int right = left + 1;
+        size_t target = index;
+        size_t left = 2 * index + 1;
+        size_t right = left + 1;
 
         if (left < heap->length &&
                 heap->data[left]->count < heap->data[target]->count) {

--- a/contents/monte_carlo_integration/code/c/monte_carlo.c
+++ b/contents/monte_carlo_integration/code/c/monte_carlo.c
@@ -24,7 +24,7 @@ double monte_carlo(unsigned int samples) {
 }
 
 int main() {
-    srand(time(NULL));
+    srand((unsigned int)time(NULL));
 
     double estimate = monte_carlo(1000000);
 

--- a/contents/split-operator_method/code/c/split_op.c
+++ b/contents/split-operator_method/code/c/split_op.c
@@ -34,10 +34,10 @@ void fft(double complex *x, size_t n, bool inverse) {
     fftw_plan p;
 
     if (inverse) {
-        p = fftw_plan_dft_1d(n, (fftw_complex*)x, (fftw_complex*)y,
+        p = fftw_plan_dft_1d((int)n, (fftw_complex*)x, (fftw_complex*)y,
                              FFTW_BACKWARD, FFTW_ESTIMATE);
     } else {
-        p = fftw_plan_dft_1d(n, (fftw_complex*)x, (fftw_complex*)y,
+        p = fftw_plan_dft_1d((int)n, (fftw_complex*)x, (fftw_complex*)y,
                              FFTW_FORWARD, FFTW_ESTIMATE);
     }
 
@@ -63,9 +63,9 @@ void init_params(struct params *par, double xmax, unsigned int res, double dt,
     par->im_time = im;
 
     for (size_t i = 0; i < res; ++i) {
-        par->x[i] = xmax / res - xmax + i * (2.0 * xmax / res);
+        par->x[i] = xmax / res - xmax + (double)i * (2.0 * xmax / res);
         if (i < res / 2) {
-            par->k[i] = i * M_PI / xmax;
+            par->k[i] = (double)i * M_PI / xmax;
         } else {
             par->k[i] = ((double)i - res) * M_PI / xmax;
         }

--- a/contents/split-operator_method/code/cpp/split_op.cpp
+++ b/contents/split-operator_method/code/cpp/split_op.cpp
@@ -28,9 +28,9 @@ struct Params {
         im_time = im;
 
         for (size_t i = 0; i < res; ++i) {
-            x.emplace_back(xmax / res - xmax + i * (2.0 * xmax / res));
+            x.emplace_back(xmax / res - xmax + static_cast<double>(i) * (2.0 * xmax / res));
             if (i < res / 2) {
-                k.push_back(i * M_PI / xmax);
+                k.push_back(static_cast<double>(i) * M_PI / xmax);
             } else {
                 k.push_back((static_cast<double>(i) - res) * M_PI / xmax);
             }
@@ -85,7 +85,7 @@ void fft(vector_complex &x, bool inverse) {
 
     fftw_complex *in = reinterpret_cast<fftw_complex*>(x.data());
     fftw_complex *out = reinterpret_cast<fftw_complex*>(y.data());
-    p = fftw_plan_dft_1d(x.size(), in, out,
+    p = fftw_plan_dft_1d(static_cast<int>(x.size()), in, out,
                          (inverse ? FFTW_BACKWARD : FFTW_FORWARD), FFTW_ESTIMATE);
 
     fftw_execute(p);

--- a/contents/stable_marriage_problem/code/c/stable_marriage.c
+++ b/contents/stable_marriage_problem/code/c/stable_marriage.c
@@ -5,7 +5,7 @@
 #include <time.h>
 
 struct person {
-    int id;
+    size_t id;
     struct person *partner;
     size_t *prefers;
     size_t index;
@@ -13,7 +13,7 @@ struct person {
 
 void shuffle(size_t *array, size_t size) {
     for (size_t i = size - 1; i > 0; --i) {
-        size_t j = rand() % (i + 1);
+        size_t j = (size_t)rand() % (i + 1);
         size_t tmp = array[i];
         array[i] = array[j];
         array[j] = tmp;
@@ -82,7 +82,7 @@ void free_group(struct person *group, size_t size) {
 }
 
 int main() {
-    srand(time(NULL));
+    srand((unsigned int)time(NULL));
 
     struct person men[5], women[5];
 
@@ -114,7 +114,7 @@ int main() {
     printf("\n");
 
     for (size_t i = 0; i < 5; ++i) {
-        printf("the partner of man %zu is woman %d\n", i, men[i].partner->id);
+        printf("the partner of man %zu is woman %ld\n", i, men[i].partner->id);
     }
 
     free_group(men, 5);

--- a/contents/thomas_algorithm/code/c/thomas.c
+++ b/contents/thomas_algorithm/code/c/thomas.c
@@ -16,7 +16,7 @@ void thomas(double * const a, double * const b, double * const c,
         x[i] = (x[i] - a[i] * x[i - 1]) * scale;
     }
 
-    for (int i = size - 2; i >= 0; --i) {
+    for (size_t i = size - 2; i < size - 1; --i) {
         x[i] -= y[i] * x[i + 1];
     }
 }


### PR DESCRIPTION
This PR is to remove all implicit conversions in both the C and C++ codes we have.

Each file change was put in its own commit for easier revertability.
Most changes were mainly following the compiler instructions, athough a few codes needed a change of types in their structure (looking at Huffman encoding in C).

I can confirm each code compiles correctly on my machine, *with* the Conversion error in place.

If you have trouble with compilation on Windows because of the change, please put it below and we'll see what we can do.
There should not be a problem on Linux, though.
