### PR TITLE
Use stricter formatting

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -20,7 +20,7 @@
         * [Multiplication as a Convolution](contents/convolutions/multiplication/multiplication.md)
         * [Convolutions of Images (2D)](contents/convolutions/2d/2d.md)
         * [Convolutional Theorem](contents/convolutions/convolutional_theorem/convolutional_theorem.md)
-    * [Probability Distributions](contents/probability_distributions/distributions.md)	
+    * [Probability Distributions](contents/probability_distributions/distributions.md)
 * [Tree Traversal](contents/tree_traversal/tree_traversal.md)
 * [Euclidean Algorithm](contents/euclidean_algorithm/euclidean_algorithm.md)
 * [Monte Carlo](contents/monte_carlo_integration/monte_carlo_integration.md)


### PR DESCRIPTION
Due to a trailing space in the summary, the AAA-py implementation had an erroneous link to the Probability distribution chapter.
This and [AAA-py PR#24](https://github.com/algorithm-archivists/aaa-py/pull/24) solve the problem from both sides.