### PR TITLE
Actions/checkout@v2 to actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         shell: bash --rcfile /root/.bashrc -eo pipefail {0} 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Warning is generated inside github action logs, because it uses an old version of nodejs. 
This should remove the warning, and won't break the action once github finishes migration. 

See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ for more details.